### PR TITLE
call_user_func is not always needed

### DIFF
--- a/classes/base/db/db2/expression.php
+++ b/classes/base/db/db2/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category DB2
- * @version 2012-05-10
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -320,7 +320,7 @@ abstract class Base_DB_DB2_Expression implements DB_SQL_Expression_Interface {
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/drizzle/expression.php
+++ b/classes/base/db/drizzle/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Drizzle
- * @version 2012-05-10
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -306,7 +306,7 @@ abstract class Base_DB_Drizzle_Expression implements DB_SQL_Expression_Interface
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/firebird/expression.php
+++ b/classes/base/db/firebird/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Firebird
- * @version 2012-05-10
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -313,7 +313,7 @@ abstract class Base_DB_Firebird_Expression implements DB_SQL_Expression_Interfac
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/mariadb/expression.php
+++ b/classes/base/db/mariadb/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MariaDB
- * @version 2012-05-10
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -315,7 +315,7 @@ abstract class Base_DB_MariaDB_Expression implements DB_SQL_Expression_Interface
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/mssql/expression.php
+++ b/classes/base/db/mssql/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MS SQL
- * @version 2012-05-10
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -310,7 +310,7 @@ abstract class Base_DB_MsSQL_Expression implements DB_SQL_Expression_Interface {
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/mysql/expression.php
+++ b/classes/base/db/mysql/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MySQL
- * @version 2012-05-10
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -315,7 +315,7 @@ abstract class Base_DB_MySQL_Expression implements DB_SQL_Expression_Interface {
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/oracle/expression.php
+++ b/classes/base/db/oracle/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Oracle
- * @version 2012-05-10
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -322,7 +322,7 @@ abstract class Base_DB_Oracle_Expression implements DB_SQL_Expression_Interface 
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/orm.php
+++ b/classes/base/db/orm.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-05-20
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -85,7 +85,7 @@ abstract class Base_DB_ORM extends Kohana_Object {
 			if ( ! is_array($primary_key)) {
 				$primary_key = array($primary_key);
 			}
-			$model_key = call_user_func(array(get_class($model), 'primary_key'));
+			$model_key = $model::primary_key();
 			$count = count($model_key);
 			for ($i = 0; $i < $count; $i++) {
 				$column = $model_key[$i];

--- a/classes/base/db/orm/delete/proxy.php
+++ b/classes/base/db/orm/delete/proxy.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-02-01
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -60,14 +60,14 @@ abstract class Base_DB_ORM_Delete_Proxy extends Kohana_Object implements DB_SQL_
 	public function __construct($model) {
 		$name = $model;
 		$model = DB_ORM_Model::model_name($name);
-		$this->source = new DB_DataSource(call_user_func(array($model, 'data_source')));
+		$this->source = new DB_DataSource($model::data_source());
 		$builder = 'DB_' . $this->source->dialect . '_Delete_Builder';
 		$this->builder = new $builder($this->source);
 		$extension = DB_ORM_Model::builder_name($name);
 		if (class_exists($extension)) {
 			$this->extension = new $extension($this->builder);
 		}
-		$table = call_user_func(array($model, 'table'));
+		$table = $model::table();
 		$this->builder->from($table);
 	}
 

--- a/classes/base/db/orm/field.php
+++ b/classes/base/db/orm/field.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-03-05
+ * @version 2012-08-03
  *
  * @abstract
  *
@@ -213,7 +213,7 @@ abstract class Base_DB_ORM_Field extends Kohana_Object {
 		if (isset($this->metadata['enum']) && ! in_array($value, $this->metadata['enum'])) {
 			return FALSE;
 		}
-		if (isset($this->metadata['callback']) && call_user_func(array($this->model, $this->metadata['callback']), $value)) {
+		if (isset($this->metadata['callback']) && $this->model->{$this->metadata['callback']}($value)) {
 			return FALSE;
 		}
 		return TRUE;

--- a/classes/base/db/orm/insert/proxy.php
+++ b/classes/base/db/orm/insert/proxy.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-02-01
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -68,14 +68,14 @@ abstract class Base_DB_ORM_Insert_Proxy extends Kohana_Object implements DB_SQL_
 	public function __construct($model) {
 		$name = $model;
 		$model = DB_ORM_Model::model_name($name);
-		$this->source = new DB_DataSource(call_user_func(array($model, 'data_source')));
+		$this->source = new DB_DataSource($model::data_source());
 		$builder = 'DB_' . $this->source->dialect . '_Insert_Builder';
 		$this->builder = new $builder($this->source);
 		$extension = DB_ORM_Model::builder_name($name);
 		if (class_exists($extension)) {
 			$this->extension = new $extension($this->builder);
 		}
-		$table = call_user_func(array($model, 'table'));
+		$table = $model::table();
 		$this->builder->into($table);
 		$this->model = $model;
 	}
@@ -147,7 +147,7 @@ abstract class Base_DB_ORM_Insert_Proxy extends Kohana_Object implements DB_SQL_
 	 * @return integer                              the last insert id
 	 */
 	public function execute() {
-		$is_auto_incremented = call_user_func(array($this->model, 'is_auto_incremented'));
+		$is_auto_incremented = $this->model::is_auto_incremented();
 		$connection = DB_Connection_Pool::instance()->get_connection($this->source);
 		$connection->execute($this->statement());
 		$primary_key = ($is_auto_incremented) ? $connection->get_last_insert_id() : 0;

--- a/classes/base/db/orm/model.php
+++ b/classes/base/db/orm/model.php
@@ -187,17 +187,16 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 *                                              deleted
 	 */
 	public function delete($reset = FALSE) {
-		$self = get_class($this);
-		$is_savable = call_user_func(array($self, 'is_savable'));
+		$is_savable = static::is_savable();
 		if ( ! $is_savable) {
 			throw new Kohana_Marshalling_Exception('Message: Failed to delete record from database. Reason: Model is not savable.', array(':class' => self::get_called_class()));
 		}
-		$primary_key = call_user_func(array($self, 'primary_key'));
+		$primary_key = static::primary_key();
 		if ( ! is_array($primary_key) || empty($primary_key)) {
 			throw new Kohana_Marshalling_Exception('Message: Failed to delete record from database. Reason: No primary key has been declared.');
 		}
-		$data_source = call_user_func(array($self, 'data_source'));
-		$table = call_user_func(array($self, 'table'));
+		$data_source = static::data_source();
+		$table = static::table();
 		$builder = DB_SQL::delete($data_source)->from($table);
 		foreach ($primary_key as $column) {
 			$builder->where($column, DB_SQL_Operator::_EQUAL_TO_, $this->fields[$column]->value);
@@ -268,10 +267,9 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 *                                              table
 	 */
 	public function is_saved() {
-		$self = get_class($this);
-		$data_source = call_user_func(array($self, 'data_source'));
-		$table = call_user_func(array($self, 'table'));
-		$primary_key = call_user_func(array($self, 'primary_key'));
+		$data_source = static::data_source();
+		$table = static::table();
+		$primary_key = static::primary_key();
 		$builder = DB_SQL::select($data_source)->from($table)->limit(1);
 		foreach ($primary_key as $column) {
 			$builder->where($column, DB_SQL_Operator::_EQUAL_TO_, $this->fields[$column]->value);
@@ -301,8 +299,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 * @return string                               the generated hash code
 	 */
 	protected function hash_code() {
-		$self = get_class($this);
-		$primary_key = call_user_func(array($self, 'primary_key'));
+		$primary_key = static::primary_key();
 		if (is_array($primary_key) && ! empty($primary_key)) {
 			if (self::is_auto_incremented()) {
 				$column = $primary_key[0];
@@ -353,13 +350,12 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 */
 	public function load(Array $columns = array()) {
 		if (empty($columns)) {
-			$self = get_class($this);
-			$primary_key = call_user_func(array($self, 'primary_key'));
+			$primary_key = static::primary_key();
 			if ( ! is_array($primary_key) || empty($primary_key)) {
 				throw new Kohana_Marshalling_Exception('Message: Failed to load record from database. Reason: No primary key has been declared.');
 			}
-			$data_source = call_user_func(array($self, 'data_source'));
-			$table = call_user_func(array($self, 'table'));
+			$data_source = static::data_source();
+			$table = static::table();
 			$builder = DB_SQL::select($data_source)->from($table)->limit(1);
 			foreach ($primary_key as $column) {
 				$builder->where($column, DB_SQL_Operator::_EQUAL_TO_, $this->fields[$column]->value);
@@ -430,17 +426,16 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 *                                              after the save is done
 	 */
 	public function save($reload = FALSE) {
-		$self = get_class($this);
-		$is_savable = call_user_func(array($self, 'is_savable'));
+		$is_savable = static::is_savable();
 		if ( ! $is_savable) {
 			throw new Kohana_Marshalling_Exception('Message: Failed to save record to database. Reason: Model is not savable.', array(':class' => self::get_called_class()));
 		}
-		$primary_key = call_user_func(array($self, 'primary_key'));
+		$primary_key = static::primary_key();
 		if ( ! is_array($primary_key) || empty($primary_key)) {
 			throw new Kohana_Marshalling_Exception('Message: Failed to save record to database. Reason: No primary key has been declared.');
 		}
-		$data_source = call_user_func(array($self, 'data_source'));
-		$table = call_user_func(array($self, 'table'));
+		$data_source = static::data_source();
+		$table = static::table();
 		$columns = array_keys($this->fields);
 		$hash_code = $this->hash_code();
 		$do_insert = is_null($hash_code);
@@ -484,7 +479,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 			}
 		}
 		if ($do_insert) {
-			$is_auto_incremented = call_user_func(array($self, 'is_auto_incremented'));
+			$is_auto_incremented = static::is_auto_incremented();
 			if ($is_auto_incremented || is_null($hash_code)) {
 				foreach ($primary_key as $column) {
 					$index = array_search($column, $columns);
@@ -540,9 +535,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 			);
 
 			$expected = array_flip($expected);
-
-			$self = get_class($this);
-			$primary_key = call_user_func(array($self, 'primary_key'));
+			$primary_key = static::primary_key();
 
 			// Remove primary key(s)
 			foreach ($primary_key AS $key) {

--- a/classes/base/db/orm/model.php
+++ b/classes/base/db/orm/model.php
@@ -68,6 +68,12 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	protected $relations = array();
 
 	/**
+	 * Validation object created before creating/updating
+	 * @var Validation
+	 */
+	protected $_validation = NULL;
+
+	/**
 	 * This constructor instantiates this class.
 	 *
 	 * @access public
@@ -144,6 +150,27 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	}
 
 	/**
+	 * Initializes validation rules, and labels
+	 *
+	 * @return void
+	 */
+	protected function _validation() {
+		$fields = array_merge(
+			$this->fields,
+			$this->aliases,
+			$this->adaptors
+		);
+
+		// Build the validation object with its rules
+		$this->_validation = Validation::factory($fields)
+			->bind(':model', $this);
+
+		foreach (static::rules() AS $field => $rules) {
+			$this->_validation->rules($field, $rules);
+		}
+	}
+
+	/**
 	 * This function will return an array of column/value mappings.
 	 *
 	 * @access public
@@ -158,6 +185,34 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 			$buffer[$name] = $field->value;
 		}
 		return $buffer;
+	}
+
+	/**
+	 * Validates the model's data
+	 *
+	 * @param  Validation $extra_validation Validation object
+	 * @return DB_ORM_Model
+	 */
+	public function check(Validation $extra_validation = NULL)
+	{
+		// Always build a new validation object
+		$this->_validation();
+
+		// Determine if any external validation failed
+		$extra_errors = ($extra_validation AND ! $extra_validation->check());
+
+		if ( ! $this->_validation->check() OR $extra_errors) {
+			$exception = new DB_ORM_Validation_Exception($this->errors_filename($this), $this->_validation);
+
+			if ($extra_errors) {
+				// Merge any possible errors from the external object
+				$exception->add_object('_external', $extra_validation);
+			}
+			
+			throw $exception;
+		}
+
+		return $this;
 	}
 
 	/**
@@ -301,7 +356,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	protected function hash_code() {
 		$primary_key = static::primary_key();
 		if (is_array($primary_key) && ! empty($primary_key)) {
-			if (self::is_auto_incremented()) {
+			if (static::is_auto_incremented()) {
 				$column = $primary_key[0];
 				if ( ! isset($this->fields[$column])) {
 					throw new Kohana_InvalidProperty_Exception('Message: Unable to generate hash code for model. Reason: Primary key contains a non-existent field name.', array(':primary_key' => $primary_key));
@@ -425,7 +480,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 * @param boolean $reload                       whether the model should be reloaded
 	 *                                              after the save is done
 	 */
-	public function save($reload = FALSE) {
+	public function save($reload = FALSE, Validation $validation = NULL) {
 		$is_savable = static::is_savable();
 		if ( ! $is_savable) {
 			throw new Kohana_Marshalling_Exception('Message: Failed to save record to database. Reason: Model is not savable.', array(':class' => self::get_called_class()));
@@ -434,6 +489,10 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 		if ( ! is_array($primary_key) || empty($primary_key)) {
 			throw new Kohana_Marshalling_Exception('Message: Failed to save record to database. Reason: No primary key has been declared.');
 		}
+		
+		// Require model validation before saving
+		$this->check($validation);
+		
 		$data_source = static::data_source();
 		$table = static::table();
 		$columns = array_keys($this->fields);
@@ -564,6 +623,23 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 		}
 	}
 
+	/**
+	 * This function returns current Model's Validation object.
+	 *
+	 * @access public
+	 * @return Validation
+	 */
+	public function validation()
+	{
+		if ( ! isset($this->_validation))
+		{
+			// Initialize the validation object
+			$this->_validation();
+		}
+
+		return $this->_validation;
+	}
+
 	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	/**
@@ -611,6 +687,20 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	}
 
 	/**
+	 * This function returns the filename which contains error messages.
+	 *
+	 * @access public
+	 * @static
+	 * @return string                               the data source name
+	 */
+	public static function errors_filename() {
+		list($model) = func_get_args();
+
+		// Just get the Model's name and strip the 'Model_Leap_'
+		return substr(get_class($model), 11);
+	}
+
+	/**
 	 * This function returns an instance of the specified model.
 	 *
 	 * @access public
@@ -631,10 +721,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 * @return boolean                              whether the primary key auto increments
 	 */
 	public static function is_auto_incremented() {
-		if (count(self::primary_key()) > 1) {
-			return FALSE;
-		}
-		return TRUE;
+		return (count(static::primary_key()) === 1);
 	}
 
 	/**
@@ -674,6 +761,17 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 */
 	public static function primary_key() {
 		return array('ID');
+	}
+
+	/**
+	 * This function returns the array of rules for the Validation.
+	 *
+	 * @access public
+	 * @static
+	 * @return array                                array of rules for Validation
+	 */
+	public static function rules() {
+		return array();
 	}
 
 	/**

--- a/classes/base/db/orm/mptt.php
+++ b/classes/base/db/orm/mptt.php
@@ -266,7 +266,7 @@ abstract class Base_DB_ORM_MPTT extends DB_ORM_Model {
             ->where($this->right_column, '>=', $this->{$this->right_column})
             ->where($this->scope_column, '=', $this->{$this->scope_column});
 
-		foreach (call_user_func(array(get_class($this), 'primary_key')) as $col) {
+		foreach (static::primary_key() as $col) {
 			$parents->where($col, '<>', $this->{$col});
 		}
 

--- a/classes/base/db/orm/relation/belongsto.php
+++ b/classes/base/db/orm/relation/belongsto.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-04-01
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -43,7 +43,7 @@ abstract class Base_DB_ORM_Relation_BelongsTo extends DB_ORM_Relation {
 		// the parent key (i.e. candidate key) is an ordered list of field names in the parent model
 		$this->metadata['parent_key'] = (isset($metadata['parent_key']))
 			? (array) $metadata['parent_key']
-			: call_user_func(array($this->metadata['parent_model'], 'primary_key'));
+			: $this->metadata['parent_model']::primary_key();
 
 		// the child model is the referencing table
 		$this->metadata['child_model'] = get_class($model);
@@ -60,9 +60,9 @@ abstract class Base_DB_ORM_Relation_BelongsTo extends DB_ORM_Relation {
 	 */
 	protected function load() {
 		$parent_model = $this->metadata['parent_model'];
-		$parent_table = call_user_func(array($parent_model, 'table'));
+		$parent_table = $parent_model::table();
 		$parent_key = $this->metadata['parent_key'];
-		$parent_source = call_user_func(array($parent_model, 'data_source'));
+		$parent_source = $parent_model::data_source();
 
 		$child_key = $this->metadata['child_key'];
 

--- a/classes/base/db/orm/relation/hasmany.php
+++ b/classes/base/db/orm/relation/hasmany.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-04-01
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -43,7 +43,7 @@ abstract class Base_DB_ORM_Relation_HasMany extends DB_ORM_Relation {
 		// the parent key (i.e. candidate key) is an ordered list of field names in the parent model
 		$this->metadata['parent_key'] = (isset($metadata['parent_key']))
 			? (array) $metadata['parent_key']
-			: call_user_func(array($this->metadata['parent_model'], 'primary_key'));
+			: $this->metadata['parent_model']::primary_key();
 
 		// the through model is the pivot table
 		if (isset($metadata['through_model'])) {
@@ -77,15 +77,15 @@ abstract class Base_DB_ORM_Relation_HasMany extends DB_ORM_Relation {
 		$parent_key = $this->metadata['parent_key'];
 
 		$child_model = $this->metadata['child_model'];
-		$child_table = call_user_func(array($child_model, 'table'));
+		$child_table = $child_model::table();
 		$child_key = $this->metadata['child_key'];
-		$child_source = call_user_func(array($child_model, 'data_source'));
+		$child_source = $child_model::data_source();
 
 		if (isset($this->metadata['through_model']) && isset($this->metadata['through_keys'])) {
 			$through_model = $this->metadata['through_model'];
-			$through_table = call_user_func(array($through_model, 'table'));
+			$through_table = $through_model::table();
 			$through_keys = $this->metadata['through_keys'];
-			$through_source = call_user_func(array($through_model, 'data_source'));
+			$through_source = $through_model::data_source();
 
 			if ($through_source != $child_source) {
 				$builder = DB_SQL::select($through_source)

--- a/classes/base/db/orm/relation/hasone.php
+++ b/classes/base/db/orm/relation/hasone.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-04-01
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -43,7 +43,7 @@ abstract class Base_DB_ORM_Relation_HasOne extends DB_ORM_Relation {
 		// the parent key (i.e. candidate key) is an ordered list of field names in the parent model
 		$this->metadata['parent_key'] = (isset($metadata['parent_key']))
 			? (array) $metadata['parent_key']
-			: call_user_func(array($this->metadata['parent_model'], 'primary_key'));
+			: $this->metadata['parent_model']::primary_key();
 
 		// the child model is the referencing table
 		$this->metadata['child_model'] = DB_ORM_Model::model_name($metadata['child_model']);
@@ -62,9 +62,9 @@ abstract class Base_DB_ORM_Relation_HasOne extends DB_ORM_Relation {
 		$parent_key = $this->metadata['parent_key'];
 
 		$child_model = $this->metadata['child_model'];
-		$child_table = call_user_func(array($child_model, 'table'));
+		$child_table = $child_model::table();
 		$child_key = $this->metadata['child_key'];
-		$child_source = call_user_func(array($child_model, 'data_source'));
+		$child_source = $child_model::data_source();
 
 		$builder = DB_SQL::select($child_source)
 			->all("{$child_table}.*")

--- a/classes/base/db/orm/select/proxy.php
+++ b/classes/base/db/orm/select/proxy.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-03-30
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -77,9 +77,9 @@ abstract class Base_DB_ORM_Select_Proxy  extends Kohana_Object implements DB_SQL
 	public function __construct($model, Array $columns = array()) {
 		$name = $model;
 		$model = DB_ORM_Model::model_name($name);
-		$this->source = new DB_DataSource(call_user_func(array($model, 'data_source')));
+		$this->source = new DB_DataSource($model::data_source());
 		$builder = 'DB_' . $this->source->dialect . '_Select_Builder';
-		$this->table = call_user_func(array($model, 'table'));
+		$this->table = $model::table();
 		$this->builder = new $builder($this->source, $columns);
 		if (empty($columns)) {
 			$this->builder->all("{$this->table}.*");

--- a/classes/base/db/orm/update/proxy.php
+++ b/classes/base/db/orm/update/proxy.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-02-01
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -60,14 +60,14 @@ abstract class Base_DB_ORM_Update_Proxy extends Kohana_Object implements DB_SQL_
 	public function __construct($model) {
 		$name = $model;
 		$model = DB_ORM_Model::model_name($name);
-		$this->source = new DB_DataSource(call_user_func(array($model, 'data_source')));
+		$this->source = new DB_DataSource($model::data_source());
 		$builder = 'DB_' . $this->source->dialect . '_Update_Builder';
 		$this->builder = new $builder($this->source);
 		$extension = DB_ORM_Model::builder_name($name);
 		if (class_exists($extension)) {
 			$this->extension = new $extension($this->builder);
 		}
-		$table = call_user_func(array($model, 'table'));
+		$table = $model::table();
 		$this->builder->table($table);
 	}
 

--- a/classes/base/db/orm/validation/exception.php
+++ b/classes/base/db/orm/validation/exception.php
@@ -1,0 +1,177 @@
+<?php defined('SYSPATH') or die('No direct script access.');
+/**
+ * @package Leap
+ * @category ORM
+ * @author Kohana Team
+ * @copyright (c) 2009-2012 Kohana Team
+ * @license http://kohanaframework.org/license
+ * @version 2012-08-03
+ */
+class Base_DB_ORM_Validation_Exception extends Kohana_Exception {
+
+	/**
+   * Array of validation objects
+   * @var array
+   */
+	protected $_objects = array();
+
+	/**
+   * The alias of the main ORM model this exception was created for
+   * @var string
+   */
+	protected $_alias = NULL;
+
+	/**
+	 * Constructs a new exception for the specified model
+	 *
+	 * @param  string     $alias       The alias to use when looking for error messages
+	 * @param  Validation $object      The Validation object of the model
+	 * @param  string     $message     The error message
+	 * @param  array      $values      The array of values for the error message
+	 * @param  integer    $code        The error code for the exception
+	 * @return void
+	 */
+	public function __construct($alias, Validation $object, $message = 'Failed to validate array', array $values = NULL, $code = 0) {
+		$this->_alias = $alias;
+		$this->_objects['_object'] = $object;
+		$this->_objects['_has_many'] = FALSE;
+
+		parent::__construct($message, $values, $code);
+	}
+
+	/**
+	 * Adds a Validation object to this exception
+	 *
+	 *     // The following will add a validation object for a profile model
+	 *     // inside the exception for a user model.
+	 *     $e->add_object('profile', $validation);
+	 *     // The errors array will now look something like this
+	 *     // array
+	 *     // (
+	 *     //   'username' => 'This field is required',
+	 *     //   'profile'  => array
+	 *     //   (
+	 *     //     'first_name' => 'This field is required',
+	 *     //   ),
+	 *     // );
+	 *
+	 * @param  string     $alias    The relationship alias from the model
+	 * @param  Validation $object   The Validation object to merge
+	 * @param  mixed      $has_many The array key to use if this exception can be merged multiple times
+	 * @return DB_ORM_Validation_Exception
+	 */
+	public function add_object($alias, Validation $object, $has_many = FALSE) {
+		// We will need this when generating errors
+		$this->_objects[$alias]['_has_many'] = ($has_many !== FALSE);
+
+		if ($has_many === TRUE) {
+			// This is most likely a has_many relationship
+			$this->_objects[$alias][]['_object'] = $object;
+		}
+		elseif ($has_many) {
+			// This is most likely a has_many relationship
+			$this->_objects[$alias][$has_many]['_object'] = $object;
+		}
+		else {
+			$this->_objects[$alias]['_object'] = $object;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Merges an DB_ORM_Validation_Exception object into the current exception
+	 * Useful when you want to combine errors into one array
+	 *
+	 * @param  DB_ORM_Validation_Exception $object   The exception to merge
+	 * @param  mixed                       $has_many The array key to use if this exception can be merged multiple times
+	 * @return DB_ORM_Validation_Exception
+	 */
+	public function merge(DB_ORM_Validation_Exception $object, $has_many = FALSE) {
+		$alias = $object->alias();
+
+		// We will need this when generating errors
+		$this->_objects[$alias]['_has_many'] = ($has_many !== FALSE);
+
+		if ($has_many === TRUE) {
+			// This is most likely a has_many relationship
+			$this->_objects[$alias][] = $object->objects();
+		}
+		elseif ($has_many) {
+			// This is most likely a has_many relationship
+			$this->_objects[$alias][$has_many] = $object->objects();
+		}
+		else {
+			$this->_objects[$alias] = $object->objects();
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Returns a merged array of the errors from all the Validation objects in this exception
+	 *
+	 *     // Will load Model_User errors from messages/orm-validation/user.php
+	 *     $e->errors('orm-validation');
+	 *
+	 * @param   string  $directory Directory to load error messages from
+	 * @param   mixed   $translate Translate the message
+	 * @return  array
+	 * @see generate_errors()
+	 */
+	public function errors($directory = NULL, $translate = TRUE) {
+		return $this->generate_errors($this->_alias, $this->_objects, $directory, $translate);
+	}
+
+	/**
+	 * Recursive method to fetch all the errors in this exception
+	 *
+	 * @param  string $alias     Alias to use for messages file
+	 * @param  array  $array     Array of Validation objects to get errors from
+	 * @param  string $directory Directory to load error messages from
+	 * @param  mixed  $translate Translate the message
+	 * @return array
+	 */
+	protected function generate_errors($alias, array $array, $directory, $translate) {
+		$errors = array();
+
+		foreach ($array as $key => $object) {
+			if (is_array($object)) {
+				$errors[$key] = $this->generate_errors($key, $object, $directory, $translate);
+			}
+			elseif ($object instanceof Validation) {
+				if ($directory === NULL) {
+					// Return the raw errors
+					$file = NULL;
+				}
+				else {
+					$file = trim($directory.'/'.$alias, '/');
+				}
+
+				// Merge in this array of errors
+				$errors += $object->errors($file, $translate);
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Returns the protected _objects property from this exception
+	 *
+	 * @return array
+	 */
+	public function objects() {
+		return $this->_objects;
+	}
+
+	/**
+	 * Returns the protected _alias property from this exception
+	 *
+	 * @return string
+	 */
+	public function alias() {
+		return $this->_alias;
+	}
+}
+?>

--- a/classes/base/db/postgresql/expression.php
+++ b/classes/base/db/postgresql/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category PostgreSQL
- * @version 2012-07-28
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -327,7 +327,7 @@ abstract class Base_DB_PostgreSQL_Expression implements DB_SQL_Expression_Interf
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/sql/tokenizer.php
+++ b/classes/base/db/sql/tokenizer.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category SQL
- * @version 2012-05-10
+ * @version 2012-08-03
  *
  * @see http://www.sqlite.org/c3ref/complete.html
  * @see http://www.opensource.apple.com/source/SQLite/SQLite-74/public_source/src/complete.c
@@ -664,7 +664,7 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 	 */
 	public static function is_keyword($token, $dialect) {
 		$compiler = 'DB_' . $dialect . '_Expression';
-		$result = call_user_func(array($compiler, 'is_keyword'), $token);
+		$result = $compiler::is_keyword($token);
 		return $result;
 	}
 

--- a/classes/base/db/sqlite/expression.php
+++ b/classes/base/db/sqlite/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category SQLite
- * @version 2012-05-10
+ * @version 2012-08-03
  *
  * @abstract
  */
@@ -324,7 +324,7 @@ abstract class Base_DB_SQLite_Expression implements DB_SQL_Expression_Interface 
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/db/orm/validation/exception.php
+++ b/classes/db/orm/validation/exception.php
@@ -1,0 +1,12 @@
+<?php defined('SYSPATH') or die('No direct script access.');
+/**
+ * @package Leap
+ * @category ORM
+ * @author Kohana Team
+ * @copyright (c) 2009-2012 Kohana Team
+ * @license http://kohanaframework.org/license
+ * @version 2012-08-03
+ * @abstract
+ */
+class DB_ORM_Validation_Exception extends Base_DB_ORM_Validation_Exception {}
+?>


### PR DESCRIPTION
Don't get mad! I discovered that there is code that can be optimized.

Instead of

``` php
<?php
$self = get_class($this);
$primary_key = call_user_func(array($self, 'primary_key'));
```

you can do

``` php
<?php
$primary_key = static::primary_key();
```

And this is not the only example where `call_user_func()` and `call_user_func_array()` is used when it's actually not needed. Of course, I didn't touch the code where these functions are actualy needed.

Why, you may ask. - Because it's more code than needed and it's 4X-8X slower. Here, I wrote a test: https://gist.github.com/3247681

I changed 21 files and I hope that I didn't break anything. :)
