### PR TITLE
Added user refresh function to Auth class

### DIFF
--- a/classes/Base/Auth/Leap.php
+++ b/classes/Base/Auth/Leap.php
@@ -212,10 +212,10 @@ abstract class Base_Auth_Leap extends Auth {
 			if ($user->password === $password) { // Authentication Successful
 
 				if ($user->banned == 1) {
-					$errors['banned'] = $user->ban_reason;
+					$this->errors['banned'] = $user->ban_reason;
 				}
 				else if (($user->activated == 0) && ! empty($this->_config['activation'])) {
-					$errors['not_activated'] = '';
+					$this->errors['not_activated'] = '';
 				}
 				else {
 					if ($remember === TRUE) {

--- a/classes/Base/Auth/Leap.php
+++ b/classes/Base/Auth/Leap.php
@@ -322,6 +322,24 @@ abstract class Base_Auth_Leap extends Auth {
 	}
 
 	/**
+	 * This function refreshes the current user's object.
+	 *
+	 * @access public
+	 * @return boolean                           whether the user has been refreshed or not
+	 */
+	public function refresh_user() {
+		$user = $this->get_user();
+
+		if ( ! $user) {
+			return FALSE;
+		}
+		
+		$user = DB_ORM::model($this->models['user'], array($user->id));
+
+		return parent::complete_login($user);
+	}
+
+	/**
 	 * This function logs the current user out.
 	 *
 	 * @access public


### PR DESCRIPTION
I ran into an issue when creating a user profile page that the current user is stored in session by Auth won't be reloaded until the user logs back in again. This is my quick and dirty fix so that $auth->refresh_user() can be called after a major change to a user that might be logged in. There might be a much better way to do it.

Also thanks to everybody who works on the project is very useful :)
