### PR TITLE
Big changes has been done.

### DIFF
--- a/classes/base/csv.php
+++ b/classes/base/csv.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category CSV
- * @version 2012-05-31
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -307,7 +307,7 @@ abstract class Base_CSV extends Kohana_Object implements ArrayAccess, Countable,
 	 * @return boolean                              whether the CSV file was saved
 	 */
 	public function save($file_name = NULL) {
-		if ( ! is_null($file_name)) {
+		if ($file_name !== NULL) {
 			$this->file_name = $file_name;
 		}
 		$result = @file_put_contents($this->file_name, $this->render());
@@ -380,7 +380,7 @@ abstract class Base_CSV extends Kohana_Object implements ArrayAccess, Countable,
 		if ( ! is_array($value)) {
 			throw new Kohana_InvalidArgument_Exception('Message: Unable to set value. Reason: Value must be an array.', array(':type' => gettype($value)));
 		}
-		else if (is_null($offset)) {
+		else if ($offset === NULL) {
 			$this->data[] = $value;
 		}
 		else {

--- a/classes/base/db/connection.php
+++ b/classes/base/db/connection.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Connection
- * @version 2012-05-25
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -291,12 +291,12 @@ abstract class Base_DB_Connection extends Kohana_Object {
 				return (object) $record;
 			break;
 			default:
-				if ( ! isset(self::$cached_objects[$type])) {
+				if ( ! isset(static::$cached_objects[$type])) {
 					$object = new $type();
-					self::$cached_objects[$type] = serialize($object);
+					static::$cached_objects[$type] = serialize($object);
 				}
 				else {
-					$object = unserialize( (string) self::$cached_objects[$type]);
+					$object = unserialize( (string) static::$cached_objects[$type]);
 				}
 				foreach ($record as $key => $value) {
 					$object->{$key} = $value;

--- a/classes/base/db/connection.php
+++ b/classes/base/db/connection.php
@@ -110,7 +110,7 @@ abstract class Base_DB_Connection extends Kohana_Object {
 	 */
 	protected function cache($sql, $type, $results = NULL) {
 		if ($this->data_source->cache->enabled) {
-			if ( ! is_null($results)) {
+			if ($results !== NULL) {
 				if ($this->data_source->cache->lifetime > 0) {
 					Kohana::cache($this->cache_key, $results, $this->data_source->cache->lifetime);
 				}

--- a/classes/base/db/connection/pool.php
+++ b/classes/base/db/connection/pool.php
@@ -122,7 +122,7 @@ abstract class Base_DB_Connection_Pool extends Kohana_Object implements Countabl
 	 *                                              can be added
 	 */
 	public function add_connection(DB_Connection $connection) {
-		if ( ! is_null($connection)) {
+		if ($connection !== NULL) {
 			$connection_id = spl_object_hash($connection);
 			if ( ! isset($this->lookup[$connection_id])) {
 				if ($this->count() >= $this->settings['max_size']) {
@@ -207,7 +207,7 @@ abstract class Base_DB_Connection_Pool extends Kohana_Object implements Countabl
 	 * @param DB_Connection $connection             the connection to be released
 	 */
 	public function release(DB_Connection $connection) {
-		if ( ! is_null($connection)) {
+		if ($connection !== NULL) {
 			$connection_id = spl_object_hash($connection);
 			if (isset($this->lookup[$connection_id])) {
 				$source_id = $this->lookup[$connection_id];
@@ -249,7 +249,7 @@ abstract class Base_DB_Connection_Pool extends Kohana_Object implements Countabl
 	 * @return DB_Connection_Pool               	a singleton instance of this class
 	 */
 	public static function instance() {
-		if (is_null(static::$instance)) {
+		if (static::$instance === NULL) {
 			register_shutdown_function(array('DB_Connection_Pool', 'autorelease'));
 			static::$instance = new DB_Connection_Pool();
 		}

--- a/classes/base/db/connection/pool.php
+++ b/classes/base/db/connection/pool.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Connection
- * @version 2012-08-03
+ * @version 2012-08-16
  *
  * @see http://stackoverflow.com/questions/1353822/how-to-implement-database-connection-pool-in-php
  * @see http://www.webdevelopersjournal.com/columns/connection_pool.html
@@ -249,11 +249,11 @@ abstract class Base_DB_Connection_Pool extends Kohana_Object implements Countabl
 	 * @return DB_Connection_Pool               	a singleton instance of this class
 	 */
 	public static function instance() {
-		if (is_null(self::$instance)) {
+		if (is_null(static::$instance)) {
 			register_shutdown_function(array('DB_Connection_Pool', 'autorelease'));
-			self::$instance = new DB_Connection_Pool();
+			static::$instance = new DB_Connection_Pool();
 		}
-		return self::$instance;
+		return static::$instance;
 	}
 
 }

--- a/classes/base/db/datasource.php
+++ b/classes/base/db/datasource.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Connection
- * @version 2012-05-20
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -109,7 +109,7 @@ abstract class Base_DB_DataSource extends Kohana_Object {
 	protected function init($settings, $id = NULL) {
 		$this->settings = array();
 
-		if (is_null($id)) {
+		if ($id === NULL) {
 			$this->settings['id'] = (isset($settings['id']))
 				? (string) $settings['id']
 				: 'unique_id.' . uniqid();

--- a/classes/base/db/db2/connection/pdo.php
+++ b/classes/base/db/db2/connection/pdo.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category DB2
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/ref.pdo-ibm.connection.php
  *
@@ -54,7 +54,7 @@ abstract class Base_DB_DB2_Connection_PDO extends DB_SQL_Connection_PDO {
 					$attributes[PDO::ATTR_PERSISTENT] = TRUE;
 				}
 				$this->connection = new PDO($connection_string, $this->data_source->username, $this->data_source->password, $attributes);
-				$this->resource_id = self::$counter++;
+				$this->resource_id = static::$counter++;
 			}
 			catch (PDOException $ex) {
 				$this->connection = NULL;

--- a/classes/base/db/db2/connection/standard.php
+++ b/classes/base/db/db2/connection/standard.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category DB2
- * @version 2012-05-25
+ * @version 2012-08-16
  *
  * @see http://php.net/manual/en/ref.ibm-db2.php
  *
@@ -99,7 +99,7 @@ abstract class Base_DB_DB2_Connection_Standard extends DB_SQL_Connection_Standar
 			throw new Kohana_SQL_Exception('Message: Failed to query SQL statement. Reason: Unable to find connection.');
 		}
 		$result_set = $this->cache($sql, $type);
-		if ( ! is_null($result_set)) {
+		if ($result_set !== NULL) {
 			$this->sql = $sql;
 			return $result_set;
 		}

--- a/classes/base/db/db2/expression.php
+++ b/classes/base/db/db2/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category DB2
- * @version 2012-08-15
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -319,7 +319,7 @@ abstract class Base_DB_DB2_Expression implements DB_SQL_Expression_Interface {
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/db2/expression.php
+++ b/classes/base/db/db2/expression.php
@@ -79,7 +79,7 @@ abstract class Base_DB_DB2_Expression implements DB_SQL_Expression_Interface {
 		if ( ! is_string($expr)) {
 			throw new Kohana_InvalidArgument_Exception('Message: Invalid alias token specified. Reason: Token must be a string.', array(':expr' => $expr));
 		}
-		return self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . self::_CLOSING_QUOTE_CHARACTER_;
+		return static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . static::_CLOSING_QUOTE_CHARACTER_;
 	}
 
 	/**
@@ -142,7 +142,7 @@ abstract class Base_DB_DB2_Expression implements DB_SQL_Expression_Interface {
 		}
 		$parts = explode('.', $expr);
 		foreach ($parts as &$part) {
-			$part = self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . self::_CLOSING_QUOTE_CHARACTER_;
+			$part = static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . static::_CLOSING_QUOTE_CHARACTER_;
 		}
 		$expr = implode('.', $parts);
 		return $expr;
@@ -337,7 +337,7 @@ abstract class Base_DB_DB2_Expression implements DB_SQL_Expression_Interface {
 				return "x'" . $expr->as_hexcode() . "'";
 			}
 			else {
-				return self::prepare_value( (string) $expr); // Convert the object to a string
+				return static::prepare_value( (string) $expr); // Convert the object to a string
 			}
 		}
 		else if (is_integer($expr)) {
@@ -372,7 +372,7 @@ abstract class Base_DB_DB2_Expression implements DB_SQL_Expression_Interface {
 		$count = count($parts);
 		for ($i = 0; $i < $count; $i++) {
 			$parts[$i] = (trim($parts[$i]) != '*')
-				? self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . self::_CLOSING_QUOTE_CHARACTER_
+				? static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . static::_CLOSING_QUOTE_CHARACTER_
 				: '*';
 		}
 		if (isset($parts[$count - 1]) && ($parts[$count - 1] != '*')) {
@@ -404,11 +404,11 @@ abstract class Base_DB_DB2_Expression implements DB_SQL_Expression_Interface {
 	 * @see http://publib.boulder.ibm.com/infocenter/dzichelp/v2r2/index.jsp?topic=%2Fcom.ibm.db2z10.doc.sqlref%2Fsrc%2Ftpc%2Fdb2z_reservedwords.htm
 	 */
 	public static function is_keyword($token) {
-		if (is_null(self::$xml)) {
-			self::$xml = XML::load('config/sql/db2.xml');
+		if (is_null(static::$xml)) {
+			static::$xml = XML::load('config/sql/db2.xml');
 		}
 		$token = strtoupper($token);
-		$nodes = self::$xml->xpath("/sql/dialect[@name='db2' and @version='10']/keywords[keyword = '{$token}']");
+		$nodes = static::$xml->xpath("/sql/dialect[@name='db2' and @version='10']/keywords[keyword = '{$token}']");
 		return ! empty($nodes);
 	}
 

--- a/classes/base/db/db2/expression.php
+++ b/classes/base/db/db2/expression.php
@@ -404,7 +404,7 @@ abstract class Base_DB_DB2_Expression implements DB_SQL_Expression_Interface {
 	 * @see http://publib.boulder.ibm.com/infocenter/dzichelp/v2r2/index.jsp?topic=%2Fcom.ibm.db2z10.doc.sqlref%2Fsrc%2Ftpc%2Fdb2z_reservedwords.htm
 	 */
 	public static function is_keyword($token) {
-		if (is_null(static::$xml)) {
+		if (static::$xml === NULL) {
 			static::$xml = XML::load('config/sql/db2.xml');
 		}
 		$token = strtoupper($token);

--- a/classes/base/db/db2/select/builder.php
+++ b/classes/base/db/db2/select/builder.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category DB2
- * @version 2012-02-22
+ * @version 2012-08-16
  *
  * @see http://publib.boulder.ibm.com/infocenter/db2luw/v8/index.jsp?topic=/com.ibm.db2.udb.doc/admin/r0000879.htm
  * @see http://publib.boulder.ibm.com/infocenter/iseries/v5r4/topic/sqlp/rbafytexas.htm
@@ -49,7 +49,7 @@ abstract class Base_DB_DB2_Select_Builder extends DB_SQL_Select_Builder {
 			? implode(', ', $this->data['column'])
 			: $this->data['wildcard'];
 
-		if ( ! is_null($this->data['from'])) {
+		if ($this->data['from'] !== NULL) {
 			$sql .= " FROM {$this->data['from']}";
 		}
 

--- a/classes/base/db/drizzle/connection/standard.php
+++ b/classes/base/db/drizzle/connection/standard.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Drizzle
- * @version 2012-05-25
+ * @version 2012-08-16
  *
  * @see http://devzone.zend.com/1504/getting-started-with-drizzle-and-php/
  * @see https://github.com/barce/partition_benchmarks/blob/master/db.php
@@ -92,7 +92,7 @@ abstract class Base_DB_Drizzle_Connection_Standard extends DB_SQL_Connection_Sta
 			throw new Kohana_SQL_Exception('Message: Failed to query SQL statement. Reason: Unable to find connection.');
 		}
 		$result_set = $this->cache($sql, $type);
-		if ( ! is_null($result_set)) {
+		if ($result_set !== NULL) {
 			$this->insert_id = FALSE;
 			$this->sql = $sql;
 			return $result_set;

--- a/classes/base/db/drizzle/expression.php
+++ b/classes/base/db/drizzle/expression.php
@@ -388,7 +388,7 @@ abstract class Base_DB_Drizzle_Expression implements DB_SQL_Expression_Interface
 	 * @return boolean                          whether the token is a reserved keyword
 	 */
 	public static function is_keyword($token) {
-		if (is_null(static::$xml)) {
+		if (static::$xml === NULL) {
 			static::$xml = XML::load('config/sql/mysql.xml');
 		}
 		$token = strtoupper($token);

--- a/classes/base/db/drizzle/expression.php
+++ b/classes/base/db/drizzle/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Drizzle
- * @version 2012-08-15
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -305,7 +305,7 @@ abstract class Base_DB_Drizzle_Expression implements DB_SQL_Expression_Interface
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/drizzle/expression.php
+++ b/classes/base/db/drizzle/expression.php
@@ -76,7 +76,7 @@ abstract class Base_DB_Drizzle_Expression implements DB_SQL_Expression_Interface
 		if ( ! is_string($expr)) {
 			throw new Kohana_InvalidArgument_Exception('Message: Invalid alias token specified. Reason: Token must be a string.', array(':expr' => $expr));
 		}
-		return self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . self::_CLOSING_QUOTE_CHARACTER_;
+		return static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . static::_CLOSING_QUOTE_CHARACTER_;
 	}
 
 	/**
@@ -139,7 +139,7 @@ abstract class Base_DB_Drizzle_Expression implements DB_SQL_Expression_Interface
 		}
 		$parts = explode('.', $expr);
 		foreach ($parts as &$part) {
-			$part = self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . self::_CLOSING_QUOTE_CHARACTER_;
+			$part = static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . static::_CLOSING_QUOTE_CHARACTER_;
 		}
 		$expr = implode('.', $parts);
 		return $expr;
@@ -323,7 +323,7 @@ abstract class Base_DB_Drizzle_Expression implements DB_SQL_Expression_Interface
 				return "x'" . $expr->as_hexcode() . "'";
 			}
 			else {
-				return self::prepare_value( (string) $expr); // Convert the object to a string
+				return static::prepare_value( (string) $expr); // Convert the object to a string
 			}
 		}
 		else if (is_integer($expr)) {
@@ -358,7 +358,7 @@ abstract class Base_DB_Drizzle_Expression implements DB_SQL_Expression_Interface
 		$count = count($parts);
 		for ($i = 0; $i < $count; $i++) {
 			$parts[$i] = (trim($parts[$i]) != '*')
-				? self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . self::_CLOSING_QUOTE_CHARACTER_
+				? static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . static::_CLOSING_QUOTE_CHARACTER_
 				: '*';
 		}
 		if (isset($parts[$count - 1]) && ($parts[$count - 1] != '*')) {
@@ -388,11 +388,11 @@ abstract class Base_DB_Drizzle_Expression implements DB_SQL_Expression_Interface
 	 * @return boolean                          whether the token is a reserved keyword
 	 */
 	public static function is_keyword($token) {
-		if (is_null(self::$xml)) {
-			self::$xml = XML::load('config/sql/mysql.xml');
+		if (is_null(static::$xml)) {
+			static::$xml = XML::load('config/sql/mysql.xml');
 		}
 		$token = strtoupper($token);
-		$nodes = self::$xml->xpath("/sql/dialect[@name='mysql' and @version='5.6']/keywords[keyword = '{$token}']");
+		$nodes = static::$xml->xpath("/sql/dialect[@name='mysql' and @version='5.6']/keywords[keyword = '{$token}']");
 		return ! empty($nodes);
 	}
 

--- a/classes/base/db/drizzle/select/builder.php
+++ b/classes/base/db/drizzle/select/builder.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Drizzle
- * @version 2012-02-22
+ * @version 2012-08-16
  *
  * @see http://dev.mysql.com/doc/refman/5.0/en/select.html
  *
@@ -48,7 +48,7 @@ abstract class Base_DB_Drizzle_Select_Builder extends DB_SQL_Select_Builder {
 			? implode(', ', $this->data['column'])
 			: $this->data['wildcard'];
 
-		if ( ! is_null($this->data['from'])) {
+		if ($this->data['from'] !== NULL) {
 			$sql .= " FROM {$this->data['from']}";
 		}
 

--- a/classes/base/db/firebird/connection/pdo.php
+++ b/classes/base/db/firebird/connection/pdo.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Firebird
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/ref.pdo-firebird.php
  *
@@ -59,7 +59,7 @@ abstract class Base_DB_Firebird_Connection_PDO extends DB_SQL_Connection_PDO {
 					$attributes[PDO::ATTR_PERSISTENT] = TRUE;
 				}
 				$this->connection = new PDO($connection_string, $this->data_source->username, $this->data_source->password, $attributes);
-				$this->resource_id = self::$counter++;
+				$this->resource_id = static::$counter++;
 			}
 			catch (PDOException $ex) {
 				$this->connection = NULL;

--- a/classes/base/db/firebird/connection/standard.php
+++ b/classes/base/db/firebird/connection/standard.php
@@ -31,7 +31,7 @@
  *
  * @package Leap
  * @category Firebird
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://us3.php.net/manual/en/book.ibase.php
  * @see http://us2.php.net/manual/en/ibase.installation.php
@@ -111,7 +111,7 @@ abstract class Base_DB_Firebird_Connection_Standard extends DB_SQL_Connection_St
 			throw new Kohana_SQL_Exception('Message: Failed to query SQL statement. Reason: Unable to find connection.');
 		}
 		$result_set = $this->cache($sql, $type);
-		if ( ! is_null($result_set)) {
+		if ($result_set !== NULL) {
 			$this->sql = $sql;
 			return $result_set;
 		}

--- a/classes/base/db/firebird/expression.php
+++ b/classes/base/db/firebird/expression.php
@@ -76,7 +76,7 @@ abstract class Base_DB_Firebird_Expression implements DB_SQL_Expression_Interfac
 		if ( ! is_string($expr)) {
 			throw new Kohana_InvalidArgument_Exception('Message: Invalid alias token specified. Reason: Token must be a string.', array(':expr' => $expr));
 		}
-		return self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . self::_CLOSING_QUOTE_CHARACTER_;
+		return static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . static::_CLOSING_QUOTE_CHARACTER_;
 	}
 
 	/**
@@ -138,7 +138,7 @@ abstract class Base_DB_Firebird_Expression implements DB_SQL_Expression_Interfac
 		}
 		$parts = explode('.', $expr);
 		foreach ($parts as &$part) {
-			$part = self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . self::_CLOSING_QUOTE_CHARACTER_;
+			$part = static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . static::_CLOSING_QUOTE_CHARACTER_;
 		}
 		$expr = implode('.', $parts);
 		return $expr;
@@ -330,7 +330,7 @@ abstract class Base_DB_Firebird_Expression implements DB_SQL_Expression_Interfac
 				return "x'" . $expr->as_hexcode() . "'";
 			}
 			else {
-				return self::prepare_value( (string) $expr); // Convert the object to a string
+				return static::prepare_value( (string) $expr); // Convert the object to a string
 			}
 		}
 		else if (is_integer($expr)) {
@@ -365,7 +365,7 @@ abstract class Base_DB_Firebird_Expression implements DB_SQL_Expression_Interfac
 		$count = count($parts);
 		for ($i = 0; $i < $count; $i++) {
 			$parts[$i] = (trim($parts[$i]) != '*')
-				? self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . self::_CLOSING_QUOTE_CHARACTER_
+				? static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . static::_CLOSING_QUOTE_CHARACTER_
 				: '*';
 		}
 		if (isset($parts[$count - 1]) && ($parts[$count - 1] != '*')) {
@@ -397,11 +397,11 @@ abstract class Base_DB_Firebird_Expression implements DB_SQL_Expression_Interfac
 	 * @see http://www.firebirdsql.org/file/documentation/reference_manuals/reference_material/html/langrefupd25-reskeywords-full-reswords.html
 	 */
 	public static function is_keyword($token) {
-		if (is_null(self::$xml)) {
-			self::$xml = XML::load('config/sql/firebird.xml');
+		if (is_null(static::$xml)) {
+			static::$xml = XML::load('config/sql/firebird.xml');
 		}
 		$token = strtoupper($token);
-		$nodes = self::$xml->xpath("/sql/dialect[@name='firebird' and @version='2.5']/keywords[keyword = '{$token}']");
+		$nodes = static::$xml->xpath("/sql/dialect[@name='firebird' and @version='2.5']/keywords[keyword = '{$token}']");
 		return ! empty($nodes);
 	}
 

--- a/classes/base/db/firebird/expression.php
+++ b/classes/base/db/firebird/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Firebird
- * @version 2012-08-15
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -312,7 +312,7 @@ abstract class Base_DB_Firebird_Expression implements DB_SQL_Expression_Interfac
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/firebird/expression.php
+++ b/classes/base/db/firebird/expression.php
@@ -397,7 +397,7 @@ abstract class Base_DB_Firebird_Expression implements DB_SQL_Expression_Interfac
 	 * @see http://www.firebirdsql.org/file/documentation/reference_manuals/reference_material/html/langrefupd25-reskeywords-full-reswords.html
 	 */
 	public static function is_keyword($token) {
-		if (is_null(static::$xml)) {
+		if (static::$xml === NULL) {
 			static::$xml = XML::load('config/sql/firebird.xml');
 		}
 		$token = strtoupper($token);

--- a/classes/base/db/firebird/select/builder.php
+++ b/classes/base/db/firebird/select/builder.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Firebird
- * @version 2012-02-22
+ * @version 2012-08-16
  *
  * @see http://www.firebirdsql.org/refdocs/langrefupd20-select.html
  *
@@ -56,7 +56,7 @@ abstract class Base_DB_Firebird_Select_Builder extends DB_SQL_Select_Builder {
 			? implode(', ', $this->data['column'])
 			: $this->data['wildcard'];
 
-		if ( ! is_null($this->data['from'])) {
+		if ($this->data['from'] !== NULL) {
 			$sql .= " FROM {$this->data['from']}";
 		}
 

--- a/classes/base/db/mariadb/connection/improved.php
+++ b/classes/base/db/mariadb/connection/improved.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MariaDB
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/book.mysqli.php
  * @see http://programmers.stackexchange.com/questions/120178/whats-the-difference-between-mariadb-and-mysql
@@ -92,7 +92,7 @@ abstract class Base_DB_MariaDB_Connection_Improved extends DB_SQL_Connection_Sta
 			throw new Kohana_SQL_Exception('Message: Failed to query SQL statement. Reason: Unable to find connection.');
 		}
 		$result_set = $this->cache($sql, $type);
-		if ( ! is_null($result_set)) {
+		if ($result_set !== NULL) {
 			$this->sql = $sql;
 			return $result_set;
 		}

--- a/classes/base/db/mariadb/connection/pdo.php
+++ b/classes/base/db/mariadb/connection/pdo.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MariaDB
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/ref.pdo-mysql.connection.php
  * @see http://programmers.stackexchange.com/questions/120178/whats-the-difference-between-mariadb-and-mysql
@@ -57,7 +57,7 @@ abstract class Base_DB_MariaDB_Connection_PDO extends DB_SQL_Connection_PDO {
 					$attributes[PDO::ATTR_PERSISTENT] = TRUE;
 				}
 				$this->connection = new PDO($connection_string, $username, $password, $attributes);
-				$this->resource_id = self::$counter++;
+				$this->resource_id = static::$counter++;
 			}
 			catch (PDOException $ex) {
 				$this->connection = NULL;

--- a/classes/base/db/mariadb/connection/standard.php
+++ b/classes/base/db/mariadb/connection/standard.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MariaDB
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/book.mysql.php
  * @see http://programmers.stackexchange.com/questions/120178/whats-the-difference-between-mariadb-and-mysql
@@ -87,7 +87,7 @@ abstract class Base_DB_MariaDB_Connection_Standard extends DB_SQL_Connection_Sta
 			throw new Kohana_SQL_Exception('Message: Failed to query SQL statement. Reason: Unable to find connection.');
 		}
 		$result_set = $this->cache($sql, $type);
-		if ( ! is_null($result_set)) {
+		if ($result_set !== NULL) {
 			$this->sql = $sql;
 			return $result_set;
 		}

--- a/classes/base/db/mariadb/expression.php
+++ b/classes/base/db/mariadb/expression.php
@@ -400,7 +400,7 @@ abstract class Base_DB_MariaDB_Expression implements DB_SQL_Expression_Interface
 	 * @see http://books.google.com/books?id=cKSgkT8AAkwC&pg=PT270&lpg=PT270&dq=mariadb+reserved+keywords&source=bl&ots=S58RmNOK4N&sig=wHm0cKwcNUho8EghBgPlvH0BiPo&hl=en&sa=X&ei=7fsYT6mMF-qTiQKp6u3NCA&sqi=2&ved=0CDUQ6AEwAw#v=onepage&q=mariadb%20reserved%20keywords&f=false
 	 */
 	public static function is_keyword($token) {
-		if (is_null(static::$xml)) {
+		if (static::$xml) {
 			static::$xml = XML::load('config/sql/mysql.xml');
 		}
 		$token = strtoupper($token);

--- a/classes/base/db/mariadb/expression.php
+++ b/classes/base/db/mariadb/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MariaDB
- * @version 2012-08-15
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -314,7 +314,7 @@ abstract class Base_DB_MariaDB_Expression implements DB_SQL_Expression_Interface
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/mariadb/expression.php
+++ b/classes/base/db/mariadb/expression.php
@@ -76,7 +76,7 @@ abstract class Base_DB_MariaDB_Expression implements DB_SQL_Expression_Interface
 		if ( ! is_string($expr)) {
 			throw new Kohana_InvalidArgument_Exception('Message: Invalid alias token specified. Reason: Token must be a string.', array(':expr' => $expr));
 		}
-		return self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . self::_CLOSING_QUOTE_CHARACTER_;
+		return static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . static::_CLOSING_QUOTE_CHARACTER_;
 	}
 
 	/**
@@ -139,7 +139,7 @@ abstract class Base_DB_MariaDB_Expression implements DB_SQL_Expression_Interface
 		}
 		$parts = explode('.', $expr);
 		foreach ($parts as &$part) {
-			$part = self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . self::_CLOSING_QUOTE_CHARACTER_;
+			$part = static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . static::_CLOSING_QUOTE_CHARACTER_;
 		}
 		$expr = implode('.', $parts);
 		return $expr;
@@ -332,7 +332,7 @@ abstract class Base_DB_MariaDB_Expression implements DB_SQL_Expression_Interface
 				return "x'" . $expr->as_hexcode() . "'";
 			}
 			else {
-				return self::prepare_value( (string) $expr); // Convert the object to a string
+				return static::prepare_value( (string) $expr); // Convert the object to a string
 			}
 		}
 		else if (is_integer($expr)) {
@@ -367,7 +367,7 @@ abstract class Base_DB_MariaDB_Expression implements DB_SQL_Expression_Interface
 		$count = count($parts);
 		for ($i = 0; $i < $count; $i++) {
 			$parts[$i] = (trim($parts[$i]) != '*')
-				? self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . self::_CLOSING_QUOTE_CHARACTER_
+				? static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . static::_CLOSING_QUOTE_CHARACTER_
 				: '*';
 		}
 		if (isset($parts[$count - 1]) && ($parts[$count - 1] != '*')) {
@@ -400,11 +400,11 @@ abstract class Base_DB_MariaDB_Expression implements DB_SQL_Expression_Interface
 	 * @see http://books.google.com/books?id=cKSgkT8AAkwC&pg=PT270&lpg=PT270&dq=mariadb+reserved+keywords&source=bl&ots=S58RmNOK4N&sig=wHm0cKwcNUho8EghBgPlvH0BiPo&hl=en&sa=X&ei=7fsYT6mMF-qTiQKp6u3NCA&sqi=2&ved=0CDUQ6AEwAw#v=onepage&q=mariadb%20reserved%20keywords&f=false
 	 */
 	public static function is_keyword($token) {
-		if (is_null(self::$xml)) {
-			self::$xml = XML::load('config/sql/mysql.xml');
+		if (is_null(static::$xml)) {
+			static::$xml = XML::load('config/sql/mysql.xml');
 		}
 		$token = strtoupper($token);
-		$nodes = self::$xml->xpath("/sql/dialect[@name='mysql' and @version='5.6']/keywords[keyword = '{$token}']");
+		$nodes = static::$xml->xpath("/sql/dialect[@name='mysql' and @version='5.6']/keywords[keyword = '{$token}']");
 		return ! empty($nodes);
 	}
 

--- a/classes/base/db/mariadb/select/builder.php
+++ b/classes/base/db/mariadb/select/builder.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MariaDB
- * @version 2012-02-22
+ * @version 2012-08-16
  *
  * @see http://dev.mysql.com/doc/refman/5.0/en/select.html
  *
@@ -48,7 +48,7 @@ abstract class Base_DB_MariaDB_Select_Builder extends DB_SQL_Select_Builder {
 			? implode(', ', $this->data['column'])
 			: $this->data['wildcard'];
 
-		if ( ! is_null($this->data['from'])) {
+		if ($this->data['from'] !== NULL) {
 			$sql .= " FROM {$this->data['from']}";
 		}
 

--- a/classes/base/db/mssql/connection/pdo.php
+++ b/classes/base/db/mssql/connection/pdo.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MS SQL
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/ref.pdo-dblib.php
  *
@@ -55,7 +55,7 @@ abstract class Base_DB_MsSQL_Connection_PDO extends DB_SQL_Connection_PDO {
 					$attributes[PDO::ATTR_PERSISTENT] = TRUE;
 				}
 				$this->connection = new PDO($connection_string, $this->data_source->username, $this->data_source->password, $attributes);
-				$this->resource_id = self::$counter++;
+				$this->resource_id = static::$counter++;
 			}
 			catch (PDOException $ex) {
 				$this->connection = NULL;

--- a/classes/base/db/mssql/connection/standard.php
+++ b/classes/base/db/mssql/connection/standard.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MS SQL
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/ref.mssql.php
  *
@@ -92,7 +92,7 @@ abstract class Base_DB_MsSQL_Connection_Standard extends DB_SQL_Connection_Stand
 			throw new Kohana_SQL_Exception('Message: Failed to query SQL statement. Reason: Unable to find connection.');
 		}
 		$result_set = $this->cache($sql, $type);
-		if ( ! is_null($result_set)) {
+		if ($result_set !== NULL) {
 			$this->sql = $sql;
 			return $result_set;
 		}

--- a/classes/base/db/mssql/expression.php
+++ b/classes/base/db/mssql/expression.php
@@ -76,7 +76,7 @@ abstract class Base_DB_MsSQL_Expression implements DB_SQL_Expression_Interface {
 		if ( ! is_string($expr)) {
 			throw new Kohana_InvalidArgument_Exception('Message: Invalid alias token specified. Reason: Token must be a string.', array(':expr' => $expr));
 		}
-		return self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . self::_CLOSING_QUOTE_CHARACTER_;
+		return static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . static::_CLOSING_QUOTE_CHARACTER_;
 	}
 
 	/**
@@ -139,7 +139,7 @@ abstract class Base_DB_MsSQL_Expression implements DB_SQL_Expression_Interface {
 		}
 		$parts = explode('.', $expr);
 		foreach ($parts as &$part) {
-			$part = self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . self::_CLOSING_QUOTE_CHARACTER_;
+			$part = static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . static::_CLOSING_QUOTE_CHARACTER_;
 		}
 		$expr = implode('.', $parts);
 		return $expr;
@@ -327,7 +327,7 @@ abstract class Base_DB_MsSQL_Expression implements DB_SQL_Expression_Interface {
 				return "x'" . $expr->as_hexcode() . "'";
 			}
 			else {
-				return self::prepare_value( (string) $expr); // Convert the object to a string
+				return static::prepare_value( (string) $expr); // Convert the object to a string
 			}
 		}
 		else if (is_integer($expr)) {
@@ -362,7 +362,7 @@ abstract class Base_DB_MsSQL_Expression implements DB_SQL_Expression_Interface {
 		$count = count($parts);
 		for ($i = 0; $i < $count; $i++) {
 			$parts[$i] = (trim($parts[$i]) != '*')
-				? self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . self::_CLOSING_QUOTE_CHARACTER_
+				? static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . static::_CLOSING_QUOTE_CHARACTER_
 				: '*';
 		}
 		if (isset($parts[$count - 1]) && ($parts[$count - 1] != '*')) {
@@ -394,11 +394,11 @@ abstract class Base_DB_MsSQL_Expression implements DB_SQL_Expression_Interface {
 	 * @see http://publib.boulder.ibm.com/infocenter/dzichelp/v2r2/index.jsp?topic=%2Fcom.ibm.db2z10.doc.sqlref%2Fsrc%2Ftpc%2Fdb2z_reservedwords.htm
 	 */
 	public static function is_keyword($token) {
-		if (is_null(self::$xml)) {
-			self::$xml = XML::load('config/sql/mssql.xml');
+		if (is_null(static::$xml)) {
+			static::$xml = XML::load('config/sql/mssql.xml');
 		}
 		$token = strtoupper($token);
-		$nodes = self::$xml->xpath("/sql/dialect[@name='mssql' and @version='2008.R2']/keywords[keyword = '{$token}']");
+		$nodes = static::$xml->xpath("/sql/dialect[@name='mssql' and @version='2008.R2']/keywords[keyword = '{$token}']");
 		return ! empty($nodes);
 	}
 

--- a/classes/base/db/mssql/expression.php
+++ b/classes/base/db/mssql/expression.php
@@ -394,7 +394,7 @@ abstract class Base_DB_MsSQL_Expression implements DB_SQL_Expression_Interface {
 	 * @see http://publib.boulder.ibm.com/infocenter/dzichelp/v2r2/index.jsp?topic=%2Fcom.ibm.db2z10.doc.sqlref%2Fsrc%2Ftpc%2Fdb2z_reservedwords.htm
 	 */
 	public static function is_keyword($token) {
-		if (is_null(static::$xml)) {
+		if (static::$xml === NULL) {
 			static::$xml = XML::load('config/sql/mssql.xml');
 		}
 		$token = strtoupper($token);

--- a/classes/base/db/mssql/expression.php
+++ b/classes/base/db/mssql/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MS SQL
- * @version 2012-08-15
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -309,7 +309,7 @@ abstract class Base_DB_MsSQL_Expression implements DB_SQL_Expression_Interface {
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/mssql/schema.php
+++ b/classes/base/db/mssql/schema.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MS SQL
- * @version 2012-02-09
+ * @version 2012-08-16
  *
  * @abstract
  */

--- a/classes/base/db/mssql/select/builder.php
+++ b/classes/base/db/mssql/select/builder.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MS SQL
- * @version 2012-02-22
+ * @version 2012-08-16
  *
  * @see http://msdn.microsoft.com/en-us/library/aa260662%28v=sql.80%29.aspx
  *
@@ -54,7 +54,7 @@ abstract class Base_DB_MsSQL_Select_Builder extends DB_SQL_Select_Builder {
 			? implode(', ', $this->data['column'])
 			: $this->data['wildcard'];
 
-		if ( ! is_null($this->data['from'])) {
+		if ($this->data['from'] !== NULL) {
 			$sql .= " FROM {$this->data['from']}";
 		}
 

--- a/classes/base/db/mysql/connection/improved.php
+++ b/classes/base/db/mysql/connection/improved.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MySQL
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/book.mysqli.php
  *
@@ -88,7 +88,7 @@ abstract class Base_DB_MySQL_Connection_Improved extends DB_SQL_Connection_Stand
 			throw new Kohana_SQL_Exception('Message: Failed to query SQL statement. Reason: Unable to find connection.');
 		}
 		$result_set = $this->cache($sql, $type);
-		if ( ! is_null($result_set)) {
+		if ($result_set !== NULL) {
 			$this->sql = $sql;
 			return $result_set;
 		}

--- a/classes/base/db/mysql/connection/pdo.php
+++ b/classes/base/db/mysql/connection/pdo.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MySQL
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/ref.pdo-mysql.connection.php
  *
@@ -55,7 +55,7 @@ abstract class Base_DB_MySQL_Connection_PDO extends DB_SQL_Connection_PDO {
 					$attributes[PDO::ATTR_PERSISTENT] = TRUE;
 				}
 				$this->connection = new PDO($connection_string, $username, $password, $attributes);
-				$this->resource_id = self::$counter++;
+				$this->resource_id = static::$counter++;
 			}
 			catch (PDOException $ex) {
 				$this->connection = NULL;

--- a/classes/base/db/mysql/connection/standard.php
+++ b/classes/base/db/mysql/connection/standard.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MySQL
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/book.mysql.php
  *
@@ -84,7 +84,7 @@ abstract class Base_DB_MySQL_Connection_Standard extends DB_SQL_Connection_Stand
 			throw new Kohana_SQL_Exception('Message: Failed to query SQL statement. Reason: Unable to find connection.');
 		}
 		$result_set = $this->cache($sql, $type);
-		if ( ! is_null($result_set)) {
+		if ($result_set !== NULL) {
 			$this->sql = $sql;
 			return $result_set;
 		}

--- a/classes/base/db/mysql/expression.php
+++ b/classes/base/db/mysql/expression.php
@@ -76,7 +76,7 @@ abstract class Base_DB_MySQL_Expression implements DB_SQL_Expression_Interface {
 		if ( ! is_string($expr)) {
 			throw new Kohana_InvalidArgument_Exception('Message: Invalid alias token specified. Reason: Token must be a string.', array(':expr' => $expr));
 		}
-		return self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . self::_CLOSING_QUOTE_CHARACTER_;
+		return static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . static::_CLOSING_QUOTE_CHARACTER_;
 	}
 
 	/**
@@ -139,7 +139,7 @@ abstract class Base_DB_MySQL_Expression implements DB_SQL_Expression_Interface {
 		}
 		$parts = explode('.', $expr);
 		foreach ($parts as &$part) {
-			$part = self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . self::_CLOSING_QUOTE_CHARACTER_;
+			$part = static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . static::_CLOSING_QUOTE_CHARACTER_;
 		}
 		$expr = implode('.', $parts);
 		return $expr;
@@ -332,7 +332,7 @@ abstract class Base_DB_MySQL_Expression implements DB_SQL_Expression_Interface {
 				return "x'" . $expr->as_hexcode() . "'";
 			}
 			else {
-				return self::prepare_value( (string) $expr); // Convert the object to a string
+				return static::prepare_value( (string) $expr); // Convert the object to a string
 			}
 		}
 		else if (is_integer($expr)) {
@@ -367,7 +367,7 @@ abstract class Base_DB_MySQL_Expression implements DB_SQL_Expression_Interface {
 		$count = count($parts);
 		for ($i = 0; $i < $count; $i++) {
 			$parts[$i] = (trim($parts[$i]) != '*')
-				? self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . self::_CLOSING_QUOTE_CHARACTER_
+				? static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . static::_CLOSING_QUOTE_CHARACTER_
 				: '*';
 		}
 		if (isset($parts[$count - 1]) && ($parts[$count - 1] != '*')) {
@@ -399,11 +399,11 @@ abstract class Base_DB_MySQL_Expression implements DB_SQL_Expression_Interface {
 	 * @see http://dev.mysql.com/doc/refman/5.6/en/reserved-words.html
 	 */
 	public static function is_keyword($token) {
-		if (is_null(self::$xml)) {
-			self::$xml = XML::load('config/sql/mysql.xml');
+		if (is_null(static::$xml)) {
+			static::$xml = XML::load('config/sql/mysql.xml');
 		}
 		$token = strtoupper($token);
-		$nodes = self::$xml->xpath("/sql/dialect[@name='mysql' and @version='5.6']/keywords[keyword = '{$token}']");
+		$nodes = static::$xml->xpath("/sql/dialect[@name='mysql' and @version='5.6']/keywords[keyword = '{$token}']");
 		return ! empty($nodes);
 	}
 

--- a/classes/base/db/mysql/expression.php
+++ b/classes/base/db/mysql/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MySQL
- * @version 2012-08-15
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -314,7 +314,7 @@ abstract class Base_DB_MySQL_Expression implements DB_SQL_Expression_Interface {
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/mysql/expression.php
+++ b/classes/base/db/mysql/expression.php
@@ -399,7 +399,7 @@ abstract class Base_DB_MySQL_Expression implements DB_SQL_Expression_Interface {
 	 * @see http://dev.mysql.com/doc/refman/5.6/en/reserved-words.html
 	 */
 	public static function is_keyword($token) {
-		if (is_null(static::$xml)) {
+		if (static::$xml === NULL) {
 			static::$xml = XML::load('config/sql/mysql.xml');
 		}
 		$token = strtoupper($token);

--- a/classes/base/db/mysql/select/builder.php
+++ b/classes/base/db/mysql/select/builder.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category MySQL
- * @version 2012-02-22
+ * @version 2012-08-16
  *
  * @see http://dev.mysql.com/doc/refman/5.0/en/select.html
  *
@@ -48,7 +48,7 @@ abstract class Base_DB_MySQL_Select_Builder extends DB_SQL_Select_Builder {
 			? implode(', ', $this->data['column'])
 			: $this->data['wildcard'];
 
-		if ( ! is_null($this->data['from'])) {
+		if ($this->data['from'] !== NULL) {
 			$sql .= " FROM {$this->data['from']}";
 		}
 

--- a/classes/base/db/oracle/connection/pdo.php
+++ b/classes/base/db/oracle/connection/pdo.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Oracle
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/ref.pdo-oci.php
  *
@@ -57,7 +57,7 @@ abstract class Base_DB_Oracle_Connection_PDO extends DB_SQL_Connection_PDO {
 					$attributes[PDO::ATTR_PERSISTENT] = TRUE;
 				}
 				$this->connection = new PDO($connection_string, $this->data_source->username, $this->data_source->password, $attributes);
-				$this->resource_id = self::$counter++;
+				$this->resource_id = static::$counter++;
 			}
 			catch (PDOException $ex) {
 				$this->connection = NULL;

--- a/classes/base/db/oracle/connection/standard.php
+++ b/classes/base/db/oracle/connection/standard.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Oracle
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://php.net/manual/en/book.oci8.php
  *
@@ -126,7 +126,7 @@ abstract class Base_DB_Oracle_Connection_Standard extends DB_SQL_Connection_Stan
 		}
 		$sql = trim($sql, "; \t\n\r\0\x0B");
 		$result_set = $this->cache($sql, $type);
-		if ( ! is_null($result_set)) {
+		if ($result_set !== NULL) {
 			$this->sql = $sql;
 			return $result_set;
 		}

--- a/classes/base/db/oracle/expression.php
+++ b/classes/base/db/oracle/expression.php
@@ -78,7 +78,7 @@ abstract class Base_DB_Oracle_Expression implements DB_SQL_Expression_Interface 
 		if ( ! is_string($expr)) {
 			throw new Kohana_InvalidArgument_Exception('Message: Invalid alias token specified. Reason: Token must be a string.', array(':expr' => $expr));
 		}
-		return self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . self::_CLOSING_QUOTE_CHARACTER_;
+		return static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . static::_CLOSING_QUOTE_CHARACTER_;
 	}
 
 	/**
@@ -140,7 +140,7 @@ abstract class Base_DB_Oracle_Expression implements DB_SQL_Expression_Interface 
 		}
 		$parts = explode('.', $expr);
 		foreach ($parts as &$part) {
-			$part = self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . self::_CLOSING_QUOTE_CHARACTER_;
+			$part = static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . static::_CLOSING_QUOTE_CHARACTER_;
 		}
 		$expr = implode('.', $parts);
 		return $expr;
@@ -339,7 +339,7 @@ abstract class Base_DB_Oracle_Expression implements DB_SQL_Expression_Interface 
 				return "x'" . $expr->as_hexcode() . "'";
 			}
 			else {
-				return self::prepare_value( (string) $expr); // Convert the object to a string
+				return static::prepare_value( (string) $expr); // Convert the object to a string
 			}
 		}
 		else if (is_integer($expr)) {
@@ -374,7 +374,7 @@ abstract class Base_DB_Oracle_Expression implements DB_SQL_Expression_Interface 
 		$count = count($parts);
 		for ($i = 0; $i < $count; $i++) {
 			$parts[$i] = (trim($parts[$i]) != '*')
-				? self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . self::_CLOSING_QUOTE_CHARACTER_
+				? static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . static::_CLOSING_QUOTE_CHARACTER_
 				: '*';
 		}
 		if (isset($parts[$count - 1]) && ($parts[$count - 1] != '*')) {
@@ -406,11 +406,11 @@ abstract class Base_DB_Oracle_Expression implements DB_SQL_Expression_Interface 
 	 * @see http://docs.oracle.com/cd/B28359_01/appdev.111/b31231/appb.htm
 	 */
 	public static function is_keyword($token) {
-		if (is_null(self::$xml)) {
-			self::$xml = XML::load('config/sql/oracle.xml');
+		if (is_null(static::$xml)) {
+			static::$xml = XML::load('config/sql/oracle.xml');
 		}
 		$token = strtoupper($token);
-		$nodes = self::$xml->xpath("/sql/dialect[@name='oracle' and @version='11.1']/keywords[keyword = '{$token}']");
+		$nodes = static::$xml->xpath("/sql/dialect[@name='oracle' and @version='11.1']/keywords[keyword = '{$token}']");
 		return ! empty($nodes);
 	}
 

--- a/classes/base/db/oracle/expression.php
+++ b/classes/base/db/oracle/expression.php
@@ -406,7 +406,7 @@ abstract class Base_DB_Oracle_Expression implements DB_SQL_Expression_Interface 
 	 * @see http://docs.oracle.com/cd/B28359_01/appdev.111/b31231/appb.htm
 	 */
 	public static function is_keyword($token) {
-		if (is_null(static::$xml)) {
+		if (static::$xml === NULL) {
 			static::$xml = XML::load('config/sql/oracle.xml');
 		}
 		$token = strtoupper($token);

--- a/classes/base/db/oracle/expression.php
+++ b/classes/base/db/oracle/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Oracle
- * @version 2012-08-15
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -321,7 +321,7 @@ abstract class Base_DB_Oracle_Expression implements DB_SQL_Expression_Interface 
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/oracle/select/builder.php
+++ b/classes/base/db/oracle/select/builder.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Oracle
- * @version 2012-02-22
+ * @version 2012-08-16
  *
  * @see http://download.oracle.com/docs/cd/B14117_01/server.101/b10759/statements_10002.htm
  *
@@ -75,7 +75,7 @@ abstract class Base_DB_Oracle_Select_Builder extends DB_SQL_Select_Builder {
 			? implode(', ', $this->data['column'])
 			: $this->data['wildcard'];
 
-		if ( ! is_null($this->data['from'])) {
+		if ($this->data['from'] !== NULL) {
 			$sql .= " FROM {$this->data['from']}";
 		}
 

--- a/classes/base/db/orm.php
+++ b/classes/base/db/orm.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-05-20
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -85,7 +85,7 @@ abstract class Base_DB_ORM extends Kohana_Object {
 			if ( ! is_array($primary_key)) {
 				$primary_key = array($primary_key);
 			}
-			$model_key = call_user_func(array(get_class($model), 'primary_key'));
+			$model_key = static::primary_key();
 			$count = count($model_key);
 			for ($i = 0; $i < $count; $i++) {
 				$column = $model_key[$i];

--- a/classes/base/db/orm/delete/proxy.php
+++ b/classes/base/db/orm/delete/proxy.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-02-01
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -60,14 +60,14 @@ abstract class Base_DB_ORM_Delete_Proxy extends Kohana_Object implements DB_SQL_
 	public function __construct($model) {
 		$name = $model;
 		$model = DB_ORM_Model::model_name($name);
-		$this->source = new DB_DataSource(call_user_func(array($model, 'data_source')));
+		$this->source = new DB_DataSource($model::data_source());
 		$builder = 'DB_' . $this->source->dialect . '_Delete_Builder';
 		$this->builder = new $builder($this->source);
 		$extension = DB_ORM_Model::builder_name($name);
 		if (class_exists($extension)) {
 			$this->extension = new $extension($this->builder);
 		}
-		$table = call_user_func(array($model, 'table'));
+		$table = $model::table();
 		$this->builder->from($table);
 	}
 

--- a/classes/base/db/orm/delete/proxy.php
+++ b/classes/base/db/orm/delete/proxy.php
@@ -83,7 +83,7 @@ abstract class Base_DB_ORM_Delete_Proxy extends Kohana_Object implements DB_SQL_
 	 *                                              inaccessible
 	 */
 	public function __call($function, $arguments) {
-		if ( ! is_null($this->extension)) {
+		if ($this->extension !== NULL) {
 			if (method_exists($this->extension, $function)) {
 				$result = call_user_func_array(array($this->extension, $function), $arguments);
 				if ($result instanceof DB_ORM_Builder) {

--- a/classes/base/db/orm/field.php
+++ b/classes/base/db/orm/field.php
@@ -91,7 +91,9 @@ abstract class Base_DB_ORM_Field extends Kohana_Object {
 				return $this->value;
 			break;
 			default:
-				if (isset($this->metadata[$key])) { return $this->metadata[$key]; }
+				if (array_key_exists($key, $this->metadata)) {
+					return $this->metadata[$key];
+				}
 			break;
 		}
 		throw new Kohana_InvalidProperty_Exception('Message: Unable to get the specified property. Reason: Property :key is either inaccessible or undefined.', array(':key' => $key));

--- a/classes/base/db/orm/field.php
+++ b/classes/base/db/orm/field.php
@@ -112,7 +112,7 @@ abstract class Base_DB_ORM_Field extends Kohana_Object {
 		switch ($key) {
 			case 'value':
 				if ( ! ($value instanceof DB_SQL_Expression)) {
-					if ( ! is_null($value)) {
+					if ($value !== NULL) {
 						settype($value, $this->metadata['type']);
 						if ( ! $this->validate($value)) {
 							throw new Kohana_BadData_Exception('Message: Unable to set the specified property. Reason: Value :value failed to pass validation constraints.', array(':value' => $value));

--- a/classes/base/db/orm/field.php
+++ b/classes/base/db/orm/field.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  *
@@ -122,7 +122,7 @@ abstract class Base_DB_ORM_Field extends Kohana_Object {
 						$value = $this->metadata['default'];
 					}
 				}
-				if (isset($this->metadata['callback']) AND ! call_user_func(array($this->model, $this->metadata['callback']), $value)) {
+				if (isset($this->metadata['callback']) && ! $this->model->{$this->metadata['callback']}($value)) {
 					throw new Kohana_BadData_Exception('Message: Unable to set the specified property. Reason: Value :value failed to pass validation constraints.', array(':value' => $value));
 				}
 				$this->metadata['modified'] = TRUE;

--- a/classes/base/db/orm/field/adaptor/array.php
+++ b/classes/base/db/orm/field/adaptor/array.php
@@ -22,7 +22,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -60,7 +60,7 @@ abstract class Base_DB_ORM_Field_Adaptor_Array extends DB_ORM_Field_Adaptor {
 		switch ($key) {
 			case 'value':
 				$value = $this->model->{$this->metadata['field']};
-				if ( ! is_null($value) && ! ($value instanceof DB_SQL_Expression)) {
+				if ($value !== NULL && ! ($value instanceof DB_SQL_Expression)) {
 					$value = preg_split($this->metadata['regex'], $value);
 				}
 				return $value;

--- a/classes/base/db/orm/field/adaptor/boolean.php
+++ b/classes/base/db/orm/field/adaptor/boolean.php
@@ -22,7 +22,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/language.types.boolean.php
  *
@@ -60,7 +60,7 @@ abstract class Base_DB_ORM_Field_Adaptor_Boolean extends DB_ORM_Field_Adaptor {
 		switch ($key) {
 			case 'value':
 				$value = $this->model->{$this->metadata['field']};
-				if ( ! is_null($value) && ! ($value instanceof DB_SQL_Expression)) {
+				if ($value !== NULL && ! ($value instanceof DB_SQL_Expression)) {
 					$value = ($value) ? $this->metadata['values'][0] : $this->metadata['values'][1];
 				}
 				return $value;
@@ -84,7 +84,7 @@ abstract class Base_DB_ORM_Field_Adaptor_Boolean extends DB_ORM_Field_Adaptor {
 	public /*override*/ function __set($key, $value) {
 		switch ($key) {
 			case 'value':
-				if ( ! is_null($value)) {
+				if ($value !== NULL) {
 					$true = $this->metadata['values'][0];
 					$value = (is_string($true) && is_string($value))
 						? (strcasecmp($true, $value) == 0)

--- a/classes/base/db/orm/field/adaptor/datetime.php
+++ b/classes/base/db/orm/field/adaptor/datetime.php
@@ -22,7 +22,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -58,7 +58,7 @@ abstract class Base_DB_ORM_Field_Adaptor_DateTime extends DB_ORM_Field_Adaptor {
 		switch ($key) {
 			case 'value':
 				$value = $this->model->{$this->metadata['field']};
-				if ( ! is_null($value) && ! ($value instanceof DB_SQL_Expression)) {
+				if ($value !== NULL && ! ($value instanceof DB_SQL_Expression)) {
 					$value = date($this->metadata['format'], (int) $value);
 				}
 				return $value;

--- a/classes/base/db/orm/field/adaptor/encryption.php
+++ b/classes/base/db/orm/field/adaptor/encryption.php
@@ -22,7 +22,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @see http://www.iitechs.com/kohana/userguide/api/kohana/Encrypt
  *
@@ -60,7 +60,7 @@ abstract class Base_DB_ORM_Field_Adaptor_Encryption extends DB_ORM_Field_Adaptor
 		switch ($key) {
 			case 'value':
 				$value = $this->model->{$this->metadata['field']};
-				if ( ! is_null($value) && ! ($value instanceof DB_SQL_Expression)) {
+				if ($value !== NULL && ! ($value instanceof DB_SQL_Expression)) {
 					$value = Encrypt::instance($this->metadata['config'])->decode($value);
 				}
 				return $value;
@@ -84,7 +84,7 @@ abstract class Base_DB_ORM_Field_Adaptor_Encryption extends DB_ORM_Field_Adaptor
 	public /*override*/ function __set($key, $value) {
 		switch ($key) {
 			case 'value':
-				if ( ! is_null($value)) {
+				if ($value !== NULL) {
 					$value = Encrypt::instance($this->metadata['config'])->encode($value);
 				}
 				$this->model->{$this->metadata['field']} = $value;

--- a/classes/base/db/orm/field/adaptor/gz.php
+++ b/classes/base/db/orm/field/adaptor/gz.php
@@ -22,7 +22,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/function.gzcompress.php
  * @see http://php.net/manual/en/function.gzuncompress.php
@@ -61,7 +61,7 @@ abstract class Base_DB_ORM_Field_Adaptor_GZ extends DB_ORM_Field_Adaptor {
 		switch ($key) {
 			case 'value':
 				$value = $this->model->{$this->metadata['field']};
-				if ( ! is_null($value) && ! ($value instanceof DB_SQL_Expression)) {
+				if ($value !== NULL && ! ($value instanceof DB_SQL_Expression)) {
 					$value = gzuncompress($value);
 				}
 				return $value;

--- a/classes/base/db/orm/field/adaptor/json.php
+++ b/classes/base/db/orm/field/adaptor/json.php
@@ -22,7 +22,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -62,7 +62,7 @@ abstract class Base_DB_ORM_Field_Adaptor_JSON extends DB_ORM_Field_Adaptor {
 		switch ($key) {
 			case 'value':
 				$value = $this->model->{$this->metadata['field']};
-				if ( ! is_null($value) && ! ($value instanceof DB_SQL_Expression)) {
+				if ($value !== NULL && ! ($value instanceof DB_SQL_Expression)) {
 					$start = strlen($this->metadata['prefix']);
 					$length = strlen($value) - ($start + strlen($this->metadata['suffix']));
 					if ($length >= 0) {

--- a/classes/base/db/orm/field/adaptor/number.php
+++ b/classes/base/db/orm/field/adaptor/number.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @see http://php.net/manual/en/function.number-format.php
  * @see http://api.rubyonrails.org/classes/ActionView/Helpers/NumberHelper.html
@@ -82,7 +82,7 @@ abstract class Base_DB_ORM_Field_Adaptor_Number extends DB_ORM_Field_Adaptor {
 		switch ($key) {
 			case 'value':
 				$value = $this->model->{$this->metadata['field']};
-				if ( ! is_null($value) && ! ($value instanceof DB_SQL_Expression)) {
+				if ($value !== NULL && ! ($value instanceof DB_SQL_Expression)) {
 					$value = number_format($value, $this->metadata['precision'], $this->metadata['separator'], $this->metadata['delimiter']);
 				}
 				return $value;

--- a/classes/base/db/orm/field/adaptor/object.php
+++ b/classes/base/db/orm/field/adaptor/object.php
@@ -22,7 +22,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -56,7 +56,7 @@ abstract class Base_DB_ORM_Field_Adaptor_Object  extends DB_ORM_Field_Adaptor {
 		switch ($key) {
 			case 'value':
 				$value = $this->model->{$this->metadata['field']};
-				if ( ! is_null($value) && ! ($value instanceof DB_SQL_Expression)) {
+				if ($value !== NULL && ! ($value instanceof DB_SQL_Expression)) {
 					$value = unserialize($value);
 				}
 				return $value;
@@ -80,7 +80,7 @@ abstract class Base_DB_ORM_Field_Adaptor_Object  extends DB_ORM_Field_Adaptor {
 	public /*override*/ function __set($key, $value) {
 		switch ($key) {
 			case 'value':
-				if ( ! is_null($value)) {
+				if ($value !== NULL) {
 					if ( ! (is_object($value) && ($value instanceof $this->metadata['class']))) {
 						throw new Kohana_InvalidProperty_Exception('Message: Unable to set the specified property. Reason: Value is not an instance of data type.', array(':object' => $this->metadata['class'], ':type' => gettype($value)));
 					}

--- a/classes/base/db/orm/field/adaptor/uom.php
+++ b/classes/base/db/orm/field/adaptor/uom.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -74,7 +74,7 @@ abstract class Base_DB_ORM_Field_Adaptor_UOM  extends DB_ORM_Field_Adaptor {
 			case 'value':
 				$value = $this->model->{$this->metadata['field']};
 				if ( ! is_null($value) && ! ($value instanceof DB_SQL_Expression)) {
-					$value = self::convert($value, $this->metadata['units'][0], $this->metadata['units'][1]);
+					$value = static::convert($value, $this->metadata['units'][0], $this->metadata['units'][1]);
 				}
 				return $value;
 			break;
@@ -98,7 +98,7 @@ abstract class Base_DB_ORM_Field_Adaptor_UOM  extends DB_ORM_Field_Adaptor {
 		switch ($key) {
 			case 'value':
 				if ( ! is_null($value)) {
-					$value = self::convert($value, $this->metadata['units'][1], $this->metadata['units'][0]);
+					$value = static::convert($value, $this->metadata['units'][1], $this->metadata['units'][0]);
 				}
 				$this->model->{$this->metadata['field']} = $value;
 			break;
@@ -121,7 +121,7 @@ abstract class Base_DB_ORM_Field_Adaptor_UOM  extends DB_ORM_Field_Adaptor {
 	 * @return double                           the new value
 	 */
 	protected static function convert($value, $units0, $units1) {
-		return ($value * self::parse($units0)) / self::parse($units1);
+		return ($value * static::parse($units0)) / static::parse($units1);
 	}
 
 	/**

--- a/classes/base/db/orm/field/adaptor/uom.php
+++ b/classes/base/db/orm/field/adaptor/uom.php
@@ -73,7 +73,7 @@ abstract class Base_DB_ORM_Field_Adaptor_UOM  extends DB_ORM_Field_Adaptor {
 		switch ($key) {
 			case 'value':
 				$value = $this->model->{$this->metadata['field']};
-				if ( ! is_null($value) && ! ($value instanceof DB_SQL_Expression)) {
+				if ($value !== NULL && ! ($value instanceof DB_SQL_Expression)) {
 					$value = static::convert($value, $this->metadata['units'][0], $this->metadata['units'][1]);
 				}
 				return $value;
@@ -97,7 +97,7 @@ abstract class Base_DB_ORM_Field_Adaptor_UOM  extends DB_ORM_Field_Adaptor {
 	public /*override*/ function __set($key, $value) {
 		switch ($key) {
 			case 'value':
-				if ( ! is_null($value)) {
+				if ($value !== NULL) {
 					$value = static::convert($value, $this->metadata['units'][1], $this->metadata['units'][0]);
 				}
 				$this->model->{$this->metadata['field']} = $value;

--- a/classes/base/db/orm/field/adaptor/xml.php
+++ b/classes/base/db/orm/field/adaptor/xml.php
@@ -22,7 +22,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -54,7 +54,7 @@ abstract class Base_DB_ORM_Field_Adaptor_XML extends DB_ORM_Field_Adaptor {
 		switch ($key) {
 			case 'value':
 				$value = $this->model->{$this->metadata['field']};
-				if ( ! is_null($value) && ! ($value instanceof DB_SQL_Expression)) {
+				if ($value !== NULL && ! ($value instanceof DB_SQL_Expression)) {
 					$value = new XML($value);
 				}
 				return $value;

--- a/classes/base/db/orm/field/binary.php
+++ b/classes/base/db/orm/field/binary.php
@@ -63,7 +63,7 @@ abstract class Base_DB_ORM_Field_Binary extends DB_ORM_Field {
 			$this->metadata['label'] = (string) $metadata['label'];
 		}
 
-		if (isset($metadata['default'])) {
+		if (array_key_exists('default', $metadata)) {
 			$default = $metadata['default'];
 		}
 		else if ( ! $this->metadata['nullable']) {

--- a/classes/base/db/orm/field/binary.php
+++ b/classes/base/db/orm/field/binary.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -74,7 +74,7 @@ abstract class Base_DB_ORM_Field_Binary extends DB_ORM_Field {
 		}
 
 		if ( ! ($default instanceof DB_SQL_Expression)) {
-			if ( ! is_null($default)) {
+			if ($default !== NULL) {
 				settype($default, $this->metadata['type']);
 			}
 			if ( ! $this->validate($default)) {
@@ -94,7 +94,7 @@ abstract class Base_DB_ORM_Field_Binary extends DB_ORM_Field {
 	 * @return boolean                              whether the specified value validates
 	 */
 	protected /*override*/ function validate($value) {
-		if ( ! is_null($value)) {
+		if ($value !== NULL) {
 			if (strlen($value) > $this->metadata['max_length'] && ! preg_match('/^(0|1)*$/', $value)) {
 				return FALSE;
 			}

--- a/classes/base/db/orm/field/bit.php
+++ b/classes/base/db/orm/field/bit.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -74,7 +74,7 @@ abstract class Base_DB_ORM_Field_Bit extends DB_ORM_Field {
 		}
 
 		if ( ! ($default instanceof DB_SQL_Expression)) {
-			if ( ! is_null($default)) {
+			if ($default !== NULL) {
 				settype($default, $this->metadata['type']);
 			}
 			if ( ! $this->validate($default)) {

--- a/classes/base/db/orm/field/bit.php
+++ b/classes/base/db/orm/field/bit.php
@@ -63,7 +63,7 @@ abstract class Base_DB_ORM_Field_Bit extends DB_ORM_Field {
 			$this->metadata['label'] = (string) $metadata['label'];
 		}
 
-		if (isset($metadata['default'])) {
+		if (array_key_exists('default', $metadata)) {
 			$default = $metadata['default'];
 		}
 		else if ( ! $this->metadata['nullable']) {

--- a/classes/base/db/orm/field/blob.php
+++ b/classes/base/db/orm/field/blob.php
@@ -61,7 +61,7 @@ abstract class Base_DB_ORM_Field_Blob extends DB_ORM_Field {
 			$this->metadata['label'] = (string) $metadata['label'];
 		}
 
-		if (isset($metadata['default'])) {
+		if (array_key_exists('default', $metadata)) {
 			$default = $metadata['default'];
 		}
 		else if ( ! $this->metadata['nullable']) {

--- a/classes/base/db/orm/field/blob.php
+++ b/classes/base/db/orm/field/blob.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -72,7 +72,7 @@ abstract class Base_DB_ORM_Field_Blob extends DB_ORM_Field {
 		}
 
 		if ( ! ($default instanceof DB_SQL_Expression)) {
-			if ( ! is_null($default)) {
+			if ($default !== NULL) {
 				settype($default, $this->metadata['type']);
 			}
 			if ( ! $this->validate($default)) {

--- a/classes/base/db/orm/field/boolean.php
+++ b/classes/base/db/orm/field/boolean.php
@@ -61,7 +61,7 @@ abstract class Base_DB_ORM_Field_Boolean extends DB_ORM_Field {
 			$this->metadata['label'] = (string) $metadata['label'];
 		}
 
-		if (isset($metadata['default'])) {
+		if (array_key_exists('default', $metadata)) {
 			$default = $metadata['default'];
 		}
 		else if ( ! $this->metadata['nullable']) {

--- a/classes/base/db/orm/field/boolean.php
+++ b/classes/base/db/orm/field/boolean.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -127,7 +127,7 @@ abstract class Base_DB_ORM_Field_Boolean extends DB_ORM_Field {
 						$value = $this->metadata['default'];
 					}
 				}
-				if (isset($this->metadata['callback']) AND ! call_user_func(array($this->model, $this->metadata['callback']), $value)) {
+				if (isset($this->metadata['callback']) && ! $this->model->{$this->metadata['callback']}($value)) {
 					throw new Kohana_BadData_Exception('Message: Unable to set the specified property. Reason: Value :value failed to pass validation constraints.', array(':value' => $value));
 				}
 				$this->metadata['modified'] = TRUE;

--- a/classes/base/db/orm/field/boolean.php
+++ b/classes/base/db/orm/field/boolean.php
@@ -72,7 +72,7 @@ abstract class Base_DB_ORM_Field_Boolean extends DB_ORM_Field {
 		}
 
 		if ( ! ($default instanceof DB_SQL_Expression)) {
-			if ( ! is_null($default)) {
+			if ($default !== NULL) {
 				if (is_string($default)) {
 					$default = strtolower($default);
 					if (in_array($default, array('true', 't', 'yes', 'y', '1'))) {
@@ -108,7 +108,7 @@ abstract class Base_DB_ORM_Field_Boolean extends DB_ORM_Field {
 		switch ($key) {
 			case 'value':
 				if ( ! ($value instanceof DB_SQL_Expression)) {
-					if ( ! is_null($value)) {
+					if ($value !== NULL) {
 						if (is_string($value)) {
 							$value = strtolower($value);
 							if (in_array($value, array('true', 't', 'yes', 'y', '1'))) {

--- a/classes/base/db/orm/field/data.php
+++ b/classes/base/db/orm/field/data.php
@@ -96,7 +96,7 @@ abstract class Base_DB_ORM_Field_Data extends DB_ORM_Field {
 		switch ($key) {
 			case 'value':
 				if ( ! ($value instanceof DB_SQL_Expression)) {
-					if ( ! is_null($value)) {
+					if ($value !== NULL) {
 						if (is_string($value)) {
 							$value = new Data($value, Data::HEXADECIMAL_DATA);
 						}
@@ -131,7 +131,7 @@ abstract class Base_DB_ORM_Field_Data extends DB_ORM_Field {
 	 * @return boolean                              whether the specified value validates
 	 */
 	protected /*override*/ function validate($value) {
-		if ( ! is_null($value)) {
+		if ($value !== NULL) {
 			if ( ! ($value instanceof $this->metadata['type'])) {
 				return FALSE;
 			}

--- a/classes/base/db/orm/field/data.php
+++ b/classes/base/db/orm/field/data.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -108,7 +108,7 @@ abstract class Base_DB_ORM_Field_Data extends DB_ORM_Field {
 						$value = $this->metadata['default'];
 					}
 				}
-				if (isset($this->metadata['callback']) AND ! call_user_func(array($this->model, $this->metadata['callback']), $value)) {
+				if (isset($this->metadata['callback']) && ! $this->model->{$this->metadata['callback']}($value)) {
 					throw new Kohana_BadData_Exception('Message: Unable to set the specified property. Reason: Value :value failed to pass validation constraints.', array(':value' => $value));
 				}
 				$this->metadata['modified'] = TRUE;

--- a/classes/base/db/orm/field/data.php
+++ b/classes/base/db/orm/field/data.php
@@ -61,7 +61,7 @@ abstract class Base_DB_ORM_Field_Data extends DB_ORM_Field {
 			$this->metadata['label'] = (string) $metadata['label'];
 		}
 
-		if (isset($metadata['default'])) {
+		if (array_key_exists('default', $metadata)) {
 			$default = $metadata['default'];
 		}
 		else if ( ! $this->metadata['nullable']) {

--- a/classes/base/db/orm/field/date.php
+++ b/classes/base/db/orm/field/date.php
@@ -67,7 +67,7 @@ abstract class Base_DB_ORM_Field_Date extends DB_ORM_Field {
 			$this->metadata['label'] = (string) $metadata['label'];
 		}
 
-		if (isset($metadata['default'])) {
+		if (array_key_exists('default', $metadata)) {
 			$default = $metadata['default'];
 		}
 		else if ( ! $this->metadata['nullable']) {

--- a/classes/base/db/orm/field/date.php
+++ b/classes/base/db/orm/field/date.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -78,7 +78,7 @@ abstract class Base_DB_ORM_Field_Date extends DB_ORM_Field {
 		}
 
 		if ( ! ($default instanceof DB_SQL_Expression)) {
-			if ( ! is_null($default)) {
+			if ($default !== NULL) {
 				settype($default, $this->metadata['type']);
 			}
 			if ( ! $this->validate($default)) {
@@ -98,7 +98,7 @@ abstract class Base_DB_ORM_Field_Date extends DB_ORM_Field {
 	 * @return boolean                              whether the specified value validates
 	 */
 	protected /*override*/ function validate($value) {
-		if ( ! is_null($value)) {
+		if ($value !== NULL) {
 			if ( ! preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/', $value)) {
 				return FALSE;
 			}

--- a/classes/base/db/orm/field/datetime.php
+++ b/classes/base/db/orm/field/datetime.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -78,7 +78,7 @@ abstract class Base_DB_ORM_Field_DateTime extends DB_ORM_Field {
 		}
 
 		if ( ! ($default instanceof DB_SQL_Expression)) {
-			if ( ! is_null($default)) {
+			if ($default !== NULL) {
 				settype($default, $this->metadata['type']);
 			}
 			if ( ! $this->validate($default)) {
@@ -98,7 +98,7 @@ abstract class Base_DB_ORM_Field_DateTime extends DB_ORM_Field {
 	 * @return boolean                              whether the specified value validates
 	 */
 	protected /*override*/ function validate($value) {
-		if ( ! is_null($value)) {
+		if ($value !== NULL) {
 			if ( ! preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}(\s[0-9]{2}:[0-9]{2}:[0-9]{2})?$/', $value)) {
 				return FALSE;
 			}

--- a/classes/base/db/orm/field/datetime.php
+++ b/classes/base/db/orm/field/datetime.php
@@ -67,7 +67,7 @@ abstract class Base_DB_ORM_Field_DateTime extends DB_ORM_Field {
 			$this->metadata['label'] = (string) $metadata['label'];
 		}
 
-		if (isset($metadata['default'])) {
+		if (array_key_exists('default', $metadata)) {
 			$default = $metadata['default'];
 		}
 		else if ( ! $this->metadata['nullable']) {

--- a/classes/base/db/orm/field/decimal.php
+++ b/classes/base/db/orm/field/decimal.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -128,7 +128,7 @@ abstract class Base_DB_ORM_Field_Decimal extends DB_ORM_Field {
 						$value = $this->metadata['default'];
 					}
 				}
-				if (isset($this->metadata['callback']) AND ! call_user_func(array($this->model, $this->metadata['callback']), $value)) {
+				if (isset($this->metadata['callback']) && ! $this->model->{$this->metadata['callback']}($value)) {
 					throw new Kohana_BadData_Exception('Message: Unable to set the specified property. Reason: Value :value failed to pass validation constraints.', array(':value' => $value));
 				}
 				$this->metadata['modified'] = TRUE;

--- a/classes/base/db/orm/field/decimal.php
+++ b/classes/base/db/orm/field/decimal.php
@@ -79,7 +79,7 @@ abstract class Base_DB_ORM_Field_Decimal extends DB_ORM_Field {
 			$this->metadata['label'] = (string) $metadata['label'];
 		}
 
-		if (isset($metadata['default'])) {
+		if (array_key_exists('default', $metadata)) {
 			$default = $metadata['default'];
 		}
 		else if ( ! $this->metadata['nullable']) {

--- a/classes/base/db/orm/field/decimal.php
+++ b/classes/base/db/orm/field/decimal.php
@@ -90,7 +90,7 @@ abstract class Base_DB_ORM_Field_Decimal extends DB_ORM_Field {
 		}
 
 		if ( ! ($default instanceof DB_SQL_Expression)) {
-			if ( ! is_null($default)) {
+			if ($default !== NULL) {
 				settype($default, $this->metadata['type']);
 			}
 			if ( ! $this->validate($default)) {
@@ -117,7 +117,7 @@ abstract class Base_DB_ORM_Field_Decimal extends DB_ORM_Field {
 		switch ($key) {
 			case 'value':
 				if ( ! ($value instanceof DB_SQL_Expression)) {
-					if ( ! is_null($value)) {
+					if ($value !== NULL) {
 						$value = number_format( (float) $value, $this->metadata['scale']);
 						settype($value, $this->metadata['type']);
 						if ( ! $this->validate($value)) {
@@ -151,7 +151,7 @@ abstract class Base_DB_ORM_Field_Decimal extends DB_ORM_Field {
 	 * @return boolean                              whether the specified value validates
 	 */
 	protected /*override*/ function validate($value) {
-		if ( ! is_null($value)) {
+		if ($value !== NULL) {
 			if (strlen("{$value}") > $this->metadata['precision']) {
 				return FALSE;
 			}

--- a/classes/base/db/orm/field/double.php
+++ b/classes/base/db/orm/field/double.php
@@ -86,7 +86,7 @@ abstract class Base_DB_ORM_Field_Double extends DB_ORM_Field {
 			$this->metadata['label'] = (string) $metadata['label'];
 		}
 
-		if (isset($metadata['default'])) {
+		if (array_key_exists('default', $metadata)) {
 			$default = $metadata['default'];
 		}
 		else if ($this->metadata['nullable']) {

--- a/classes/base/db/orm/field/double.php
+++ b/classes/base/db/orm/field/double.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -94,7 +94,7 @@ abstract class Base_DB_ORM_Field_Double extends DB_ORM_Field {
 		}
 
 		if ( ! ($default instanceof DB_SQL_Expression)) {
-			if ( ! is_null($default)) {
+			if ($default !== NULL) {
 				settype($default, $this->metadata['type']);
 			}
 			if ( ! $this->validate($default)) {
@@ -114,7 +114,7 @@ abstract class Base_DB_ORM_Field_Double extends DB_ORM_Field {
 	 * @return boolean                              whether the specified value validates
 	 */
 	protected /*override*/ function validate($value) {
-		if ( ! is_null($value)) {
+		if ($value !== NULL) {
 			if ($this->metadata['unsigned'] && ($value < 0.0)) {
 				return FALSE;
 			}

--- a/classes/base/db/orm/field/integer.php
+++ b/classes/base/db/orm/field/integer.php
@@ -119,7 +119,7 @@ abstract class Base_DB_ORM_Field_Integer extends DB_ORM_Field {
 		}
 
 		if ( ! ($default instanceof DB_SQL_Expression)) {
-			if ( ! is_null($default)) {
+			if ($default !== NULL) {
 				if ((PHP_INT_SIZE !== 4) OR ! is_string($default) OR ! preg_match('/^-?[0-9]+$/D', $default) OR ((bccomp($default, '-2147483648') !== -1) AND (bccomp($default, '2147483647') !== 1))) {
 					settype($default, $this->metadata['type']);
 				}
@@ -148,7 +148,7 @@ abstract class Base_DB_ORM_Field_Integer extends DB_ORM_Field {
 		switch ($key) {
 			case 'value':
 				if ( ! ($value instanceof DB_SQL_Expression)) {
-					if ( ! is_null($value)) {
+					if ($value !== NULL) {
 						if ( ! isset($this->metadata['int8fix']) OR is_int($value) OR ! preg_match('/^-?[0-9]+$/D', (string) $value) OR (bccomp( (string) $value, '-2147483648') !== -1 AND bccomp( (string) $value, '2147483647') !== 1)) {
 							settype($value, $this->metadata['type']);
 						}
@@ -183,7 +183,7 @@ abstract class Base_DB_ORM_Field_Integer extends DB_ORM_Field {
 	 * @return boolean                              whether the specified value validates
 	 */
 	protected /*override*/ function validate($value) {
-		if ( ! is_null($value)) {
+		if ($value !== NULL) {
 			if (isset($this->metadata['max_length']) AND (strlen(strval($value)) > $this->metadata['max_length'])) {
 				return FALSE;
 			}

--- a/classes/base/db/orm/field/integer.php
+++ b/classes/base/db/orm/field/integer.php
@@ -100,7 +100,7 @@ abstract class Base_DB_ORM_Field_Integer extends DB_ORM_Field {
 			$this->metadata['label'] = (string) $metadata['label'];
 		}
 
-		if (isset($metadata['default'])) {
+		if (array_key_exists('default', $metadata)) {
 			$default = $metadata['default'];
 		}
 		else if ( ! $this->metadata['nullable']) {

--- a/classes/base/db/orm/field/integer.php
+++ b/classes/base/db/orm/field/integer.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -160,7 +160,7 @@ abstract class Base_DB_ORM_Field_Integer extends DB_ORM_Field {
 						$value = $this->metadata['default'];
 					}
 				}
-				if (isset($this->metadata['callback']) AND ! call_user_func(array($this->model, $this->metadata['callback']), $value)) {
+				if (isset($this->metadata['callback']) && ! $this->model->{$this->metadata['callback']}($value)) {
 					throw new Kohana_BadData_Exception('Message: Unable to set the specified property. Reason: Value :value failed to pass validation constraints.', array(':value' => $value));
 				}
 				$this->metadata['modified'] = TRUE;

--- a/classes/base/db/orm/field/string.php
+++ b/classes/base/db/orm/field/string.php
@@ -73,7 +73,7 @@ abstract class Base_DB_ORM_Field_String extends DB_ORM_Field {
 			$this->metadata['label'] = (string) $metadata['label'];
 		}
 
-		if (isset($metadata['default'])) {
+		if (array_key_exists('default', $metadata)) {
 			$default = $metadata['default'];
 		}
 		else if ( ! $this->metadata['nullable']) {

--- a/classes/base/db/orm/field/string.php
+++ b/classes/base/db/orm/field/string.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -84,7 +84,7 @@ abstract class Base_DB_ORM_Field_String extends DB_ORM_Field {
 		}
 
 		if ( ! ($default instanceof DB_SQL_Expression)) {
-			if ( ! is_null($default)) {
+			if ($default !== NULL) {
 				settype($default, $this->metadata['type']);
 			}
 			if ( ! $this->validate($default)) {
@@ -104,7 +104,7 @@ abstract class Base_DB_ORM_Field_String extends DB_ORM_Field {
 	 * @return boolean                              whether the specified value validates
 	 */
 	protected /*override*/ function validate($value) {
-		if ( ! is_null($value)) {
+		if ($value !== NULL) {
 			if (strlen($value) > $this->metadata['max_length']) {
 				return FALSE;
 			}

--- a/classes/base/db/orm/field/text.php
+++ b/classes/base/db/orm/field/text.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -72,7 +72,7 @@ abstract class Base_DB_ORM_Field_Text extends DB_ORM_Field {
 		}
 
 		if ( ! ($default instanceof DB_SQL_Expression)) {
-			if ( ! is_null($default)) {
+			if ($default !== NULL) {
 				settype($default, $this->metadata['type']);
 			}
 			if ( ! $this->validate($default)) {

--- a/classes/base/db/orm/field/text.php
+++ b/classes/base/db/orm/field/text.php
@@ -61,7 +61,7 @@ abstract class Base_DB_ORM_Field_Text extends DB_ORM_Field {
 			$this->metadata['label'] = (string) $metadata['label'];
 		}
 
-		if (isset($metadata['default'])) {
+		if (array_key_exists('default', $metadata)) {
 			$default = $metadata['default'];
 		}
 		else if ( ! $this->metadata['nullable']) {

--- a/classes/base/db/orm/field/time.php
+++ b/classes/base/db/orm/field/time.php
@@ -67,7 +67,7 @@ abstract class Base_DB_ORM_Field_Time extends DB_ORM_Field {
 			$this->metadata['label'] = (string) $metadata['label'];
 		}
 
-		if (isset($metadata['default'])) {
+		if (array_key_exists('default', $metadata)) {
 			$default = $metadata['default'];
 		}
 		else if ( ! $this->metadata['nullable']) {

--- a/classes/base/db/orm/field/time.php
+++ b/classes/base/db/orm/field/time.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -78,7 +78,7 @@ abstract class Base_DB_ORM_Field_Time extends DB_ORM_Field {
 		}
 
 		if ( ! ($default instanceof DB_SQL_Expression)) {
-			if ( ! is_null($default)) {
+			if ($default !== NULL) {
 				settype($default, $this->metadata['type']);
 			}
 			if ( ! $this->validate($default)) {
@@ -98,7 +98,7 @@ abstract class Base_DB_ORM_Field_Time extends DB_ORM_Field {
 	 * @return boolean                              whether the specified value validates
 	 */
 	protected /*override*/ function validate($value) {
-		if ( ! is_null($value)) {
+		if ($value !== NULL) {
 			if ( ! preg_match('/^[0-9]{2}:[0-9]{2}:[0-9]{2}$/', $value)) {
 				return FALSE;
 			}

--- a/classes/base/db/orm/insert/proxy.php
+++ b/classes/base/db/orm/insert/proxy.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-02-01
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -68,14 +68,14 @@ abstract class Base_DB_ORM_Insert_Proxy extends Kohana_Object implements DB_SQL_
 	public function __construct($model) {
 		$name = $model;
 		$model = DB_ORM_Model::model_name($name);
-		$this->source = new DB_DataSource(call_user_func(array($model, 'data_source')));
+		$this->source = new DB_DataSource($model::data_source());
 		$builder = 'DB_' . $this->source->dialect . '_Insert_Builder';
 		$this->builder = new $builder($this->source);
 		$extension = DB_ORM_Model::builder_name($name);
 		if (class_exists($extension)) {
 			$this->extension = new $extension($this->builder);
 		}
-		$table = call_user_func(array($model, 'table'));
+		$table = $model::table();
 		$this->builder->into($table);
 		$this->model = $model;
 	}
@@ -147,7 +147,7 @@ abstract class Base_DB_ORM_Insert_Proxy extends Kohana_Object implements DB_SQL_
 	 * @return integer                              the last insert id
 	 */
 	public function execute() {
-		$is_auto_incremented = call_user_func(array($this->model, 'is_auto_incremented'));
+		$is_auto_incremented = $this->model::is_auto_incremented();
 		$connection = DB_Connection_Pool::instance()->get_connection($this->source);
 		$connection->execute($this->statement());
 		$primary_key = ($is_auto_incremented) ? $connection->get_last_insert_id() : 0;

--- a/classes/base/db/orm/insert/proxy.php
+++ b/classes/base/db/orm/insert/proxy.php
@@ -92,7 +92,7 @@ abstract class Base_DB_ORM_Insert_Proxy extends Kohana_Object implements DB_SQL_
 	 *                                              inaccessible
 	 */
 	public function __call($function, $arguments) {
-		if ( ! is_null($this->extension)) {
+		if ($this->extension !== NULL) {
 			if (method_exists($this->extension, $function)) {
 				$result = call_user_func_array(array($this->extension, $function), $arguments);
 				if ($result instanceof DB_ORM_Builder) {

--- a/classes/base/db/orm/model.php
+++ b/classes/base/db/orm/model.php
@@ -170,7 +170,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 * @return string                               the HTML form control
 	 */
 	public function control($name, Array $attributes = NULL) {
-		if ( ! is_array($attributes)) {
+		if ($attributes === NULL) {
 			$attributes = array();
 		}
 		$control = $this->fields[$name]->control($name, $attributes);
@@ -315,7 +315,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 					throw new Kohana_InvalidProperty_Exception('Message: Unable to generate hash code for model. Reason: Primary key contains a non-existent field name.', array(':primary_key' => $primary_key));
 				}
 				$value = $this->fields[$column]->value;
-				if ( ! is_null($value)) {
+				if ($value !== NULL) {
 					$buffer .= "{$column}={$value}";
 				}
 			}
@@ -351,7 +351,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	public function load(Array $columns = array()) {
 		if (empty($columns)) {
 			$primary_key = static::primary_key();
-			if ( ! is_array($primary_key) || empty($primary_key)) {
+			if (empty($primary_key) || ! is_array($primary_key)) {
 				throw new Kohana_Marshalling_Exception('Message: Failed to load record from database. Reason: No primary key has been declared.');
 			}
 			$data_source = static::data_source();
@@ -438,9 +438,9 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 		$table = static::table();
 		$columns = array_keys($this->fields);
 		$hash_code = $this->hash_code();
-		$do_insert = is_null($hash_code);
+		$do_insert = $hash_code === NULL;
 		if ( ! $do_insert) {
-			$do_insert = (is_null($this->metadata['saved']) || ($hash_code != $this->metadata['saved']));
+			$do_insert = ($this->metadata['saved'] === NULL || ($hash_code != $this->metadata['saved']));
 			if ($do_insert) {
 				$builder = DB_SQL::select($data_source)
 						->column(DB_SQL::expr(1), 'IsFound')
@@ -483,7 +483,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 		}
 		if ($do_insert) {
 			$is_auto_incremented = static::is_auto_incremented();
-			if ($is_auto_incremented || is_null($hash_code)) {
+			if ($is_auto_incremented || $hash_code === NULL) {
 				foreach ($primary_key as $column) {
 					$index = array_search($column, $columns);
 					if ($index !== FALSE) {
@@ -506,7 +506,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 					}
 				}
 				if ($count > 0) {
-					if ($is_auto_incremented && is_null($hash_code)) {
+					if ($is_auto_incremented && $hash_code === NULL) {
 						$this->fields[$primary_key[0]]->value = $builder->execute(TRUE);
 					}
 					else {
@@ -598,7 +598,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 */
 	public static function columns() {
 		static $columns = NULL;
-		if (is_null($columns)) {
+		if ($columns === NULL) {
 			$model = get_called_class();
 			$record = new $model();
 			$columns = array_keys($record->fields);

--- a/classes/base/db/orm/model.php
+++ b/classes/base/db/orm/model.php
@@ -189,7 +189,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	public function delete($reset = FALSE) {
 		$is_savable = static::is_savable();
 		if ( ! $is_savable) {
-			throw new Kohana_Marshalling_Exception('Message: Failed to delete record from database. Reason: Model is not savable.', array(':class' => self::get_called_class()));
+			throw new Kohana_Marshalling_Exception('Message: Failed to delete record from database. Reason: Model is not savable.', array(':class' => get_called_class()));
 		}
 		$primary_key = static::primary_key();
 		if ( ! is_array($primary_key) || empty($primary_key)) {
@@ -301,7 +301,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	protected function hash_code() {
 		$primary_key = static::primary_key();
 		if (is_array($primary_key) && ! empty($primary_key)) {
-			if (self::is_auto_incremented()) {
+			if (static::is_auto_incremented()) {
 				$column = $primary_key[0];
 				if ( ! isset($this->fields[$column])) {
 					throw new Kohana_InvalidProperty_Exception('Message: Unable to generate hash code for model. Reason: Primary key contains a non-existent field name.', array(':primary_key' => $primary_key));
@@ -428,7 +428,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	public function save($reload = FALSE) {
 		$is_savable = static::is_savable();
 		if ( ! $is_savable) {
-			throw new Kohana_Marshalling_Exception('Message: Failed to save record to database. Reason: Model is not savable.', array(':class' => self::get_called_class()));
+			throw new Kohana_Marshalling_Exception('Message: Failed to save record to database. Reason: Model is not savable.', array(':class' => get_called_class()));
 		}
 		$primary_key = static::primary_key();
 		if ( ! is_array($primary_key) || empty($primary_key)) {
@@ -599,7 +599,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	public static function columns() {
 		static $columns = NULL;
 		if (is_null($columns)) {
-			$model = self::get_called_class();
+			$model = get_called_class();
 			$record = new $model();
 			$columns = array_keys($record->fields);
 		}
@@ -638,7 +638,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 * @return boolean                              whether the primary key auto increments
 	 */
 	public static function is_auto_incremented() {
-		if (count(self::primary_key()) > 1) {
+		if (count(static::primary_key()) > 1) {
 			return FALSE;
 		}
 		return TRUE;
@@ -691,7 +691,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 * @return string                               the database table's name
 	 */
 	public static function table() {
-		$segments = preg_split('/_/', self::get_called_class());
+		$segments = preg_split('/_/', get_called_class());
 		return $segments[count($segments) - 1];
 	}
 

--- a/classes/base/db/orm/model.php
+++ b/classes/base/db/orm/model.php
@@ -154,6 +154,12 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 		foreach ($this->fields as $name => $field) {
 			$buffer[$name] = $field->value;
 		}
+		foreach ($this->aliases as $name => $alias) {
+			$buffer[$name] = $alias->value;
+		}
+		foreach ($this->adaptors as $name => $adaptor) {
+			$buffer[$name] = $adaptor->value;
+		}
 		return $buffer;
 	}
 

--- a/classes/base/db/orm/model.php
+++ b/classes/base/db/orm/model.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-15
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -187,17 +187,16 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 *                                              deleted
 	 */
 	public function delete($reset = FALSE) {
-		$self = get_class($this);
-		$is_savable = call_user_func(array($self, 'is_savable'));
+		$is_savable = static::is_savable();
 		if ( ! $is_savable) {
 			throw new Kohana_Marshalling_Exception('Message: Failed to delete record from database. Reason: Model is not savable.', array(':class' => self::get_called_class()));
 		}
-		$primary_key = call_user_func(array($self, 'primary_key'));
+		$primary_key = static::primary_key();
 		if ( ! is_array($primary_key) || empty($primary_key)) {
 			throw new Kohana_Marshalling_Exception('Message: Failed to delete record from database. Reason: No primary key has been declared.');
 		}
-		$data_source = call_user_func(array($self, 'data_source'));
-		$table = call_user_func(array($self, 'table'));
+		$data_source = static::data_source();
+		$table = static::table();
 		$builder = DB_SQL::delete($data_source)->from($table);
 		foreach ($primary_key as $column) {
 			$builder->where($column, DB_SQL_Operator::_EQUAL_TO_, $this->fields[$column]->value);
@@ -268,10 +267,9 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 *                                              table
 	 */
 	public function is_saved() {
-		$self = get_class($this);
-		$data_source = call_user_func(array($self, 'data_source'));
-		$table = call_user_func(array($self, 'table'));
-		$primary_key = call_user_func(array($self, 'primary_key'));
+		$data_source = static::data_source();
+		$table = static::table();
+		$primary_key = static::primary_key();
 		$builder = DB_SQL::select($data_source)->from($table)->limit(1);
 		foreach ($primary_key as $column) {
 			$builder->where($column, DB_SQL_Operator::_EQUAL_TO_, $this->fields[$column]->value);
@@ -301,8 +299,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 * @return string                               the generated hash code
 	 */
 	protected function hash_code() {
-		$self = get_class($this);
-		$primary_key = call_user_func(array($self, 'primary_key'));
+		$primary_key = static::primary_key();
 		if (is_array($primary_key) && ! empty($primary_key)) {
 			if (self::is_auto_incremented()) {
 				$column = $primary_key[0];
@@ -353,13 +350,12 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 */
 	public function load(Array $columns = array()) {
 		if (empty($columns)) {
-			$self = get_class($this);
-			$primary_key = call_user_func(array($self, 'primary_key'));
+			$primary_key = static::primary_key();
 			if ( ! is_array($primary_key) || empty($primary_key)) {
 				throw new Kohana_Marshalling_Exception('Message: Failed to load record from database. Reason: No primary key has been declared.');
 			}
-			$data_source = call_user_func(array($self, 'data_source'));
-			$table = call_user_func(array($self, 'table'));
+			$data_source = static::data_source();
+			$table = static::table();
 			$builder = DB_SQL::select($data_source)->from($table)->limit(1);
 			foreach ($primary_key as $column) {
 				$builder->where($column, DB_SQL_Operator::_EQUAL_TO_, $this->fields[$column]->value);
@@ -430,17 +426,16 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 	 *                                              after the save is done
 	 */
 	public function save($reload = FALSE) {
-		$self = get_class($this);
-		$is_savable = call_user_func(array($self, 'is_savable'));
+		$is_savable = static::is_savable();
 		if ( ! $is_savable) {
 			throw new Kohana_Marshalling_Exception('Message: Failed to save record to database. Reason: Model is not savable.', array(':class' => self::get_called_class()));
 		}
-		$primary_key = call_user_func(array($self, 'primary_key'));
+		$primary_key = static::primary_key();
 		if ( ! is_array($primary_key) || empty($primary_key)) {
 			throw new Kohana_Marshalling_Exception('Message: Failed to save record to database. Reason: No primary key has been declared.');
 		}
-		$data_source = call_user_func(array($self, 'data_source'));
-		$table = call_user_func(array($self, 'table'));
+		$data_source = static::data_source();
+		$table = static::table();
 		$columns = array_keys($this->fields);
 		$hash_code = $this->hash_code();
 		$do_insert = is_null($hash_code);
@@ -487,7 +482,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 			}
 		}
 		if ($do_insert) {
-			$is_auto_incremented = call_user_func(array($self, 'is_auto_incremented'));
+			$is_auto_incremented = static::is_auto_incremented();
 			if ($is_auto_incremented || is_null($hash_code)) {
 				foreach ($primary_key as $column) {
 					$index = array_search($column, $columns);
@@ -547,8 +542,7 @@ abstract class Base_DB_ORM_Model extends Kohana_Object {
 
 			$expected = array_flip($expected);
 
-			$self = get_class($this);
-			$primary_key = call_user_func(array($self, 'primary_key'));
+			$primary_key = static::primary_key();
 
 			// Remove primary key(s)
 			foreach ($primary_key AS $key) {

--- a/classes/base/db/orm/mptt.php
+++ b/classes/base/db/orm/mptt.php
@@ -186,7 +186,7 @@ abstract class Base_DB_ORM_MPTT extends DB_ORM_Model {
 	 * @return bool
 	 */
 	public function is_child($target) {
-		return ($this->parent->{self::primary_key()} === $target->{self::primary_key()});
+		return ($this->parent->{static::primary_key()} === $target->{static::primary_key()});
 	}
 
 	/**
@@ -197,7 +197,7 @@ abstract class Base_DB_ORM_MPTT extends DB_ORM_Model {
 	 * @return bool
 	 */
 	public function is_parent($target) {
-		return ($this->{self::primary_key()} === $target->parent->{self::primary_key()});
+		return ($this->{static::primary_key()} === $target->parent->{static::primary_key()});
 	}
 
 	/**
@@ -208,10 +208,10 @@ abstract class Base_DB_ORM_MPTT extends DB_ORM_Model {
 	 * @return bool
 	 */
 	public function is_sibling($target) {
-		if ($this->{self::primary_key()} === $target->{self::primary_key()}) {
+		if ($this->{static::primary_key()} === $target->{static::primary_key()}) {
 			return FALSE;
 		}
-		return ($this->parent->{self::primary_key()} === $target->parent->{self::primary_key()});
+		return ($this->parent->{static::primary_key()} === $target->parent->{static::primary_key()});
 	}
 
 	/**
@@ -330,7 +330,7 @@ abstract class Base_DB_ORM_MPTT extends DB_ORM_Model {
 				->order_by($this->left_column, $direction);
 
 		if (!$self) {
-			$siblings->where(self::primary_key(), '<>', $this->{self::primary_key()});
+			$siblings->where(static::primary_key(), '<>', $this->{static::primary_key()});
 		}
 
 		return $siblings;

--- a/classes/base/db/orm/mptt.php
+++ b/classes/base/db/orm/mptt.php
@@ -28,7 +28,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-03
+ * @version 2012-08-16
  *
  * @see https://github.com/kiall/kohana3-orm_mptt
  * @see http://dev.kohanaframework.org/projects/mptt
@@ -266,7 +266,7 @@ abstract class Base_DB_ORM_MPTT extends DB_ORM_Model {
 			->where($this->right_column, '>=', $this->{$this->right_column})
 			->where($this->scope_column, '=', $this->{$this->scope_column});
 
-		foreach (call_user_func(array(get_class($this), 'primary_key')) as $col) {
+		foreach (static::primary_key() as $col) {
 			$parents->where($col, '<>', $this->{$col});
 		}
 

--- a/classes/base/db/orm/relation.php
+++ b/classes/base/db/orm/relation.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2011-12-30
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -77,7 +77,7 @@ abstract class Base_DB_ORM_Relation extends Kohana_Object {
 	public function __get($key) {
 		switch ($key) {
 			case 'result':
-				if (is_null($this->cache)) {
+				if ($this->cache === NULL) {
 					$this->cache = $this->load();
 				}
 				return $this->cache;

--- a/classes/base/db/orm/relation/belongsto.php
+++ b/classes/base/db/orm/relation/belongsto.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-04-01
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -43,7 +43,7 @@ abstract class Base_DB_ORM_Relation_BelongsTo extends DB_ORM_Relation {
 		// the parent key (i.e. candidate key) is an ordered list of field names in the parent model
 		$this->metadata['parent_key'] = (isset($metadata['parent_key']))
 			? (array) $metadata['parent_key']
-			: call_user_func(array($this->metadata['parent_model'], 'primary_key'));
+			: $this->metadata['parent_model']::primary_key();
 
 		// the child model is the referencing table
 		$this->metadata['child_model'] = get_class($model);
@@ -60,9 +60,9 @@ abstract class Base_DB_ORM_Relation_BelongsTo extends DB_ORM_Relation {
 	 */
 	protected function load() {
 		$parent_model = $this->metadata['parent_model'];
-		$parent_table = call_user_func(array($parent_model, 'table'));
+		$parent_table = $parent_model::table();
 		$parent_key = $this->metadata['parent_key'];
-		$parent_source = call_user_func(array($parent_model, 'data_source'));
+		$parent_source = $parent_model::data_source();
 
 		$child_key = $this->metadata['child_key'];
 

--- a/classes/base/db/orm/relation/hasmany.php
+++ b/classes/base/db/orm/relation/hasmany.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-04-01
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -43,7 +43,7 @@ abstract class Base_DB_ORM_Relation_HasMany extends DB_ORM_Relation {
 		// the parent key (i.e. candidate key) is an ordered list of field names in the parent model
 		$this->metadata['parent_key'] = (isset($metadata['parent_key']))
 			? (array) $metadata['parent_key']
-			: call_user_func(array($this->metadata['parent_model'], 'primary_key'));
+			: $this->metadata['parent_model']::primary_key();
 
 		// the through model is the pivot table
 		if (isset($metadata['through_model'])) {
@@ -77,15 +77,15 @@ abstract class Base_DB_ORM_Relation_HasMany extends DB_ORM_Relation {
 		$parent_key = $this->metadata['parent_key'];
 
 		$child_model = $this->metadata['child_model'];
-		$child_table = call_user_func(array($child_model, 'table'));
+		$child_table = $child_model::table();
 		$child_key = $this->metadata['child_key'];
-		$child_source = call_user_func(array($child_model, 'data_source'));
+		$child_source = $child_model::data_source();
 
 		if (isset($this->metadata['through_model']) && isset($this->metadata['through_keys'])) {
 			$through_model = $this->metadata['through_model'];
-			$through_table = call_user_func(array($through_model, 'table'));
+			$through_table = $through_model::table();
 			$through_keys = $this->metadata['through_keys'];
-			$through_source = call_user_func(array($through_model, 'data_source'));
+			$through_source = $through_model::data_source();
 
 			if ($through_source != $child_source) {
 				$builder = DB_SQL::select($through_source)

--- a/classes/base/db/orm/relation/hasone.php
+++ b/classes/base/db/orm/relation/hasone.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-04-01
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -43,7 +43,7 @@ abstract class Base_DB_ORM_Relation_HasOne extends DB_ORM_Relation {
 		// the parent key (i.e. candidate key) is an ordered list of field names in the parent model
 		$this->metadata['parent_key'] = (isset($metadata['parent_key']))
 			? (array) $metadata['parent_key']
-			: call_user_func(array($this->metadata['parent_model'], 'primary_key'));
+			: $this->metadata['parent_model']::primary_key();
 
 		// the child model is the referencing table
 		$this->metadata['child_model'] = DB_ORM_Model::model_name($metadata['child_model']);
@@ -62,9 +62,9 @@ abstract class Base_DB_ORM_Relation_HasOne extends DB_ORM_Relation {
 		$parent_key = $this->metadata['parent_key'];
 
 		$child_model = $this->metadata['child_model'];
-		$child_table = call_user_func(array($child_model, 'table'));
+		$child_table = $child_model::table();
 		$child_key = $this->metadata['child_key'];
-		$child_source = call_user_func(array($child_model, 'data_source'));
+		$child_source = $child_model::data_source();
 
 		$builder = DB_SQL::select($child_source)
 			->all("{$child_table}.*")

--- a/classes/base/db/orm/select/proxy.php
+++ b/classes/base/db/orm/select/proxy.php
@@ -104,7 +104,7 @@ abstract class Base_DB_ORM_Select_Proxy  extends Kohana_Object implements DB_SQL
 	 *                                              inaccessible
 	 */
 	public function __call($function, $arguments) {
-		if ( ! is_null($this->extension)) {
+		if ($this->extension !== NULL) {
 			if (method_exists($this->extension, $function)) {
 				$result = call_user_func_array(array($this->extension, $function), $arguments);
 				if ($result instanceof DB_ORM_Builder) {
@@ -361,7 +361,7 @@ abstract class Base_DB_ORM_Select_Proxy  extends Kohana_Object implements DB_SQL
 	 * @return DB_ResultSet                         the result set
 	 */
 	public function query($limit = NULL) {
-		if ( ! is_null($limit)) {
+		if ($limit !== NULL) {
 			$this->limit($limit);
 		}
 		$connection = DB_Connection_Pool::instance()->get_connection($this->source);

--- a/classes/base/db/orm/select/proxy.php
+++ b/classes/base/db/orm/select/proxy.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-03-30
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -77,9 +77,9 @@ abstract class Base_DB_ORM_Select_Proxy  extends Kohana_Object implements DB_SQL
 	public function __construct($model, Array $columns = array()) {
 		$name = $model;
 		$model = DB_ORM_Model::model_name($name);
-		$this->source = new DB_DataSource(call_user_func(array($model, 'data_source')));
+		$this->source = new DB_DataSource($model::data_source());
 		$builder = 'DB_' . $this->source->dialect . '_Select_Builder';
-		$this->table = call_user_func(array($model, 'table'));
+		$this->table = $model::table();
 		$this->builder = new $builder($this->source, $columns);
 		if (empty($columns)) {
 			$this->builder->all("{$this->table}.*");

--- a/classes/base/db/orm/update/proxy.php
+++ b/classes/base/db/orm/update/proxy.php
@@ -83,7 +83,7 @@ abstract class Base_DB_ORM_Update_Proxy extends Kohana_Object implements DB_SQL_
 	 *                                              inaccessible
 	 */
 	public function __call($function, $arguments) {
-		if ( ! is_null($this->extension)) {
+		if ($this->extension !== NULL) {
 			if (method_exists($this->extension, $function)) {
 				$result = call_user_func_array(array($this->extension, $function), $arguments);
 				if ($result instanceof DB_ORM_Builder) {

--- a/classes/base/db/orm/update/proxy.php
+++ b/classes/base/db/orm/update/proxy.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-02-01
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -60,14 +60,14 @@ abstract class Base_DB_ORM_Update_Proxy extends Kohana_Object implements DB_SQL_
 	public function __construct($model) {
 		$name = $model;
 		$model = DB_ORM_Model::model_name($name);
-		$this->source = new DB_DataSource(call_user_func(array($model, 'data_source')));
+		$this->source = new DB_DataSource($model::data_source());
 		$builder = 'DB_' . $this->source->dialect . '_Update_Builder';
 		$this->builder = new $builder($this->source);
 		$extension = DB_ORM_Model::builder_name($name);
 		if (class_exists($extension)) {
 			$this->extension = new $extension($this->builder);
 		}
-		$table = call_user_func(array($model, 'table'));
+		$table = $model::table();
 		$this->builder->table($table);
 	}
 

--- a/classes/base/db/postgresql/connection/pdo.php
+++ b/classes/base/db/postgresql/connection/pdo.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category PostgreSQL
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/ref.pdo-pgsql.connection.php
  *
@@ -53,7 +53,7 @@ abstract class Base_DB_PostgreSQL_Connection_PDO extends DB_SQL_Connection_PDO {
 					$attributes[PDO::ATTR_PERSISTENT] = TRUE;
 				}
 				$this->connection = new PDO($connection_string, $this->data_source->username, $this->data_source->password, $attributes);
-				$this->resource_id = self::$counter++;
+				$this->resource_id = static::$counter++;
 			}
 			catch (PDOException $ex) {
 				$this->connection = NULL;

--- a/classes/base/db/postgresql/connection/standard.php
+++ b/classes/base/db/postgresql/connection/standard.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category PostgreSQL
- * @version 2012-08-01
+ * @version 2012-08-16
  *
  * @see http://php.net/manual/en/ref.pgsql.php
  *
@@ -93,7 +93,7 @@ abstract class Base_DB_PostgreSQL_Connection_Standard extends DB_SQL_Connection_
 			throw new Kohana_SQL_Exception('Message: Failed to query SQL statement. Reason: Unable to find connection.');
 		}
 		$result_set = $this->cache($sql, $type);
-		if ( ! is_null($result_set)) {
+		if ($result_set !== NULL) {
 			$this->sql = $sql;
 			return $result_set;
 		}

--- a/classes/base/db/postgresql/expression.php
+++ b/classes/base/db/postgresql/expression.php
@@ -411,7 +411,7 @@ abstract class Base_DB_PostgreSQL_Expression implements DB_SQL_Expression_Interf
 	 * @see http://www.postgresql.org/docs/7.3/static/sql-keywords-appendix.html
 	 */
 	public static function is_keyword($token) {
-		if (is_null(static::$xml)) {
+		if (static::$xml === NULL) {
 			static::$xml = XML::load('config/sql/postgresql.xml');
 		}
 		$token = strtoupper($token);

--- a/classes/base/db/postgresql/expression.php
+++ b/classes/base/db/postgresql/expression.php
@@ -76,7 +76,7 @@ abstract class Base_DB_PostgreSQL_Expression implements DB_SQL_Expression_Interf
 		if ( ! is_string($expr)) {
 			throw new Kohana_InvalidArgument_Exception('Message: Invalid alias token specified. Reason: Token must be a string.', array(':expr' => $expr));
 		}
-		return self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . self::_CLOSING_QUOTE_CHARACTER_;
+		return static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . static::_CLOSING_QUOTE_CHARACTER_;
 	}
 
 	/**
@@ -138,7 +138,7 @@ abstract class Base_DB_PostgreSQL_Expression implements DB_SQL_Expression_Interf
 		}
 		$parts = explode('.', $expr);
 		foreach ($parts as &$part) {
-			$part = self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . self::_CLOSING_QUOTE_CHARACTER_;
+			$part = static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . static::_CLOSING_QUOTE_CHARACTER_;
 		}
 		$expr = implode('.', $parts);
 		return $expr;
@@ -344,7 +344,7 @@ abstract class Base_DB_PostgreSQL_Expression implements DB_SQL_Expression_Interf
 				return "x'" . $expr->as_hexcode() . "'";
 			}
 			else {
-				return self::prepare_value( (string) $expr); // Convert the object to a string
+				return static::prepare_value( (string) $expr); // Convert the object to a string
 			}
 		}
 		else if (is_integer($expr)) {
@@ -379,7 +379,7 @@ abstract class Base_DB_PostgreSQL_Expression implements DB_SQL_Expression_Interf
 		$count = count($parts);
 		for ($i = 0; $i < $count; $i++) {
 			$parts[$i] = (trim($parts[$i]) != '*')
-				? self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . self::_CLOSING_QUOTE_CHARACTER_
+				? static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . static::_CLOSING_QUOTE_CHARACTER_
 				: '*';
 		}
 		if (isset($parts[$count - 1]) && ($parts[$count - 1] != '*')) {
@@ -411,11 +411,11 @@ abstract class Base_DB_PostgreSQL_Expression implements DB_SQL_Expression_Interf
 	 * @see http://www.postgresql.org/docs/7.3/static/sql-keywords-appendix.html
 	 */
 	public static function is_keyword($token) {
-		if (is_null(self::$xml)) {
-			self::$xml = XML::load('config/sql/postgresql.xml');
+		if (is_null(static::$xml)) {
+			static::$xml = XML::load('config/sql/postgresql.xml');
 		}
 		$token = strtoupper($token);
-		$nodes = self::$xml->xpath("/sql/dialect[@name='postgresql' and @version='7.3']/keywords[keyword = '{$token}']");
+		$nodes = static::$xml->xpath("/sql/dialect[@name='postgresql' and @version='7.3']/keywords[keyword = '{$token}']");
 		return ! empty($nodes);
 	}
 

--- a/classes/base/db/postgresql/expression.php
+++ b/classes/base/db/postgresql/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category PostgreSQL
- * @version 2012-08-15
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -326,7 +326,7 @@ abstract class Base_DB_PostgreSQL_Expression implements DB_SQL_Expression_Interf
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/postgresql/select/builder.php
+++ b/classes/base/db/postgresql/select/builder.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category PostgreSQL
- * @version 2012-02-22
+ * @version 2012-08-16
  *
  * @see http://www.postgresql.org/docs/9.0/static/sql-select.html
  *
@@ -48,7 +48,7 @@ abstract class Base_DB_PostgreSQL_Select_Builder extends DB_SQL_Select_Builder {
 			? implode(', ', $this->data['column'])
 			: $this->data['wildcard'];
 
-		if ( ! is_null($this->data['from'])) {
+		if ($this->data['from'] !== NULL) {
 			$sql .= " FROM {$this->data['from']}";
 		}
 

--- a/classes/base/db/resultset.php
+++ b/classes/base/db/resultset.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Connection
- * @version 2012-05-10
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -201,7 +201,7 @@ abstract class Base_DB_ResultSet extends Kohana_Object implements ArrayAccess, C
 		if (is_object($record)) {
 			try {
 				$value = $record->{$name};
-				if ( ! is_null($value)) {
+				if ($value !== NULL) {
 					return $value;
 				}
 			}

--- a/classes/base/db/sql/builder.php
+++ b/classes/base/db/sql/builder.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category SQL
- * @version 2011-12-12
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -61,7 +61,7 @@ abstract class Base_DB_SQL_Builder extends Kohana_Object implements DB_SQL_State
 	 * @return DB_SQL_Builder                   a new instance of the calling class
 	 */
 	public static function factory(DB_DataSource $source) {
-		$class = self::get_called_class();
+		$class = get_called_class();
 		return new $class($source);
 	}
 

--- a/classes/base/db/sql/connection/pdo.php
+++ b/classes/base/db/sql/connection/pdo.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category PDO
- * @version 2012-05-25
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/book.pdo.php
  * @see http://www.electrictoolbox.com/php-pdo-dsn-connection-string/
@@ -78,7 +78,7 @@ abstract class Base_DB_SQL_Connection_PDO extends DB_Connection {
 			throw new Kohana_SQL_Exception('Message: Failed to query SQL statement. Reason: Unable to find connection.');
 		}
 		$result_set = $this->cache($sql, $type);
-		if ( ! is_null($result_set)) {
+		if ($result_set !== NULL) {
 			$this->sql = $sql;
 			return $result_set;
 		}
@@ -227,7 +227,7 @@ abstract class Base_DB_SQL_Connection_PDO extends DB_Connection {
 	 * @access public
 	 */
 	public function __destruct() {
-		if ( ! is_null($this->connection)) {
+		if ($this->connection !== NULL) {
 		   unset($this->connection);
 		}
 	}

--- a/classes/base/db/sql/delete/builder.php
+++ b/classes/base/db/sql/delete/builder.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category SQL
- * @version 2012-05-11
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -124,7 +124,7 @@ abstract class Base_DB_SQL_Delete_Builder extends DB_SQL_Builder {
 			if ((($operator == DB_SQL_Operator::_IN_) || ($operator == DB_SQL_Operator::_NOT_IN_)) && ! is_array($value)) {
 				throw new Kohana_SQL_Exception('Message: Invalid build instruction. Reason: Operator requires the value to be declared as an array.', array(':column' => $column, ':operator' => $operator, ':value' => $value, ':connector' => $connector));
 			}
-			if (is_null($value)) {
+			if ($value === NULL) {
 				switch ($operator) {
 					case DB_SQL_Operator::_EQUAL_TO_:
 						$operator = DB_SQL_Operator::_IS_;

--- a/classes/base/db/sql/select/builder.php
+++ b/classes/base/db/sql/select/builder.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category SQL
- * @version 2012-05-11
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -117,7 +117,7 @@ abstract class Base_DB_SQL_Select_Builder extends DB_SQL_Builder {
 	 */
 	public function column($column, $alias = NULL) {
 		$column = $this->compiler->prepare_identifier($column);
-		if ( ! is_null($alias)) {
+		if ($alias !== NULL) {
 			$alias = $this->compiler->prepare_alias($alias);
 			$column = "{$column} AS {$alias}";
 		}
@@ -135,7 +135,7 @@ abstract class Base_DB_SQL_Select_Builder extends DB_SQL_Builder {
 	 */
 	public function from($table, $alias = NULL) {
 		$table = $this->compiler->prepare_identifier($table);
-		if ( ! is_null($alias)) {
+		if ($alias !== NULL) {
 			$alias = $this->compiler->prepare_alias($alias);
 			$table = "{$table} AS {$alias}";
 		}
@@ -154,11 +154,11 @@ abstract class Base_DB_SQL_Select_Builder extends DB_SQL_Builder {
 	 */
 	public function join($type, $table, $alias = NULL) {
 		$table = 'JOIN ' . $this->compiler->prepare_identifier($table);
-		if ( ! is_null($type)) {
+		if ($type !== NULL) {
 			$type = $this->compiler->prepare_join($type);
 			$table = "{$type} {$table}";
 		}
-		if ( ! is_null($alias)) {
+		if ($alias !== NULL) {
 			$alias = $this->compiler->prepare_alias($alias);
 			$table = "{$table} {$alias}";
 		}
@@ -260,7 +260,7 @@ abstract class Base_DB_SQL_Select_Builder extends DB_SQL_Builder {
 			if ((($operator == DB_SQL_Operator::_IN_) || ($operator == DB_SQL_Operator::_NOT_IN_)) && ! is_array($value)) {
 				throw new Kohana_SQL_Exception('Message: Invalid SQL build instruction. Reason: Operator requires the value to be declared as an array.', array(':column' => $column, ':operator' => $operator, ':value' => $value, ':connector' => $connector));
 			}
-			if (is_null($value)) {
+			if ($value === NULL) {
 				switch ($operator) {
 					case DB_SQL_Operator::_EQUAL_TO_:
 						$operator = DB_SQL_Operator::_IS_;
@@ -289,7 +289,7 @@ abstract class Base_DB_SQL_Select_Builder extends DB_SQL_Builder {
 	 * @return DB_SQL_Select_Builder            a reference to the current instance
 	 */
 	public function group_by($column) {
-		$fields = (is_array($column)) ? $column : array($column);
+		$fields = is_array($column) ? $column : array($column);
 		foreach ($fields as $field) {
 			$identifier = $this->compiler->prepare_identifier($field);
 			$this->data['group_by'][] = $identifier;
@@ -343,10 +343,10 @@ abstract class Base_DB_SQL_Select_Builder extends DB_SQL_Builder {
 			$this->data['having'][] = array($connector, "{$column} {$operator} {$value0} AND {$value1}");
 		}
 		else {
-			if ((($operator == DB_SQL_Operator::_IN_) || ($operator == DB_SQL_Operator::_NOT_IN_)) && !is_array($value)) {
+			if (($operator == DB_SQL_Operator::_IN_ || $operator == DB_SQL_Operator::_NOT_IN_) && ! is_array($value)) {
 				throw new Kohana_SQL_Exception('Message: Invalid SQL build instruction. Reason: Operator requires the value to be declared as an array.', array(':column' => $column, ':operator' => $operator, ':value' => $value, ':connector' => $connector));
 			}
-			if (is_null($value)) {
+			if ($value === NULL) {
 				switch ($operator) {
 					case DB_SQL_Operator::_EQUAL_TO_:
 						$operator = DB_SQL_Operator::_IS_;

--- a/classes/base/db/sql/tokenizer.php
+++ b/classes/base/db/sql/tokenizer.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category SQL
- * @version 2012-08-18
+ * @version 2012-08-16
  *
  * @see http://www.sqlite.org/c3ref/complete.html
  * @see http://www.opensource.apple.com/source/SQLite/SQLite-74/public_source/src/complete.c
@@ -167,16 +167,16 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 		$quote = array('`', '"');
 
 		while ($position <= $length) {
-			$char = self::char_at($statement, $position, $strlen);
+			$char = static::char_at($statement, $position, $strlen);
 			if ($char == '|') { // "operator" token
 				$lookahead = $position + 1;
-				$next = self::char_at($statement, $lookahead, $strlen);
+				$next = static::char_at($statement, $lookahead, $strlen);
 				if ($next == '|') {
 					$lookahead++;
 					$size = $lookahead - $position;
 					$token = substr($statement, $position, $size);
 					$this->tuples[] = array(
-						'type' => self::OPERATOR_TOKEN,
+						'type' => static::OPERATOR_TOKEN,
 						'token' => $token,
 					);
 					$this->size++;
@@ -184,7 +184,7 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 				}
 				else {
 					$this->tuples[] = array(
-						'type' => self::OPERATOR_TOKEN,
+						'type' => static::OPERATOR_TOKEN,
 						'token' => $char,
 					);
 					$this->size++;
@@ -194,13 +194,13 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 			}
 			else if (($char == '!') || ($char == '=')) { // "operator" token
 				$lookahead = $position + 1;
-				$next = self::char_at($statement, $lookahead, $strlen);
+				$next = static::char_at($statement, $lookahead, $strlen);
 				if ($next == '=') {
 					$lookahead++;
 					$size = $lookahead - $position;
 					$token = substr($statement, $position, $size);
 					$this->tuples[] = array(
-						'type' => self::OPERATOR_TOKEN,
+						'type' => static::OPERATOR_TOKEN,
 						'token' => $token,
 					);
 					$this->size++;
@@ -208,7 +208,7 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 				}
 				else {
 					$this->tuples[] = array(
-						'type' => self::OPERATOR_TOKEN,
+						'type' => static::OPERATOR_TOKEN,
 						'token' => $char,
 					);
 					$this->size++;
@@ -218,13 +218,13 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 			}
 			else if (($char == '<') || ($char == '>')) { // "operator" token
 				$lookahead = $position + 1;
-				$next = self::char_at($statement, $lookahead, $strlen);
+				$next = static::char_at($statement, $lookahead, $strlen);
 				if (($next == '=') || ($next == $char) || (($next == '>') && ($char == '<'))) {
 					$lookahead++;
 					$size = $lookahead - $position;
 					$token = substr($statement, $position, $size);
 					$this->tuples[] = array(
-						'type' => self::OPERATOR_TOKEN,
+						'type' => static::OPERATOR_TOKEN,
 						'token' => $token,
 					);
 					$this->size++;
@@ -232,7 +232,7 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 				}
 				else {
 					$this->tuples[] = array(
-						'type' => self::OPERATOR_TOKEN,
+						'type' => static::OPERATOR_TOKEN,
 						'token' => $char,
 					);
 					$this->size++;
@@ -245,12 +245,12 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 				$next = '';
 				do {
 					$position++;
-					$next = self::char_at($statement, $position, $strlen);
+					$next = static::char_at($statement, $position, $strlen);
 				} while(($next != '') && (in_array($next, $whitespace) || in_array($next, $eol)));
 				$size = $position - $start;
 				$token = substr($statement, $start, $size);
 				$this->tuples[] = array(
-					'type' => self::WHITESPACE_TOKEN,
+					'type' => static::WHITESPACE_TOKEN,
 					'token' => $token,
 				);
 				$this->size++;
@@ -260,12 +260,12 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 				$start = $position;
 				do {
 					$position++;
-				} while( ! in_array(self::char_at($statement, $position, $strlen), $eol));
+				} while( ! in_array(static::char_at($statement, $position, $strlen), $eol));
 				$position++;
 				$size = $position - $start;
 				$token = substr($statement, $start, $size);
 				$this->tuples[] = array(
-					'type' => self::WHITESPACE_TOKEN,
+					'type' => static::WHITESPACE_TOKEN,
 					'token' => $token,
 				);
 				$this->size++;
@@ -273,23 +273,23 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 			}
 			else if ($char == '-') { // "whitespace" token (i.e. SQL-style comment) or "operator" token
 				$lookahead = $position + 1;
-				if (($lookahead > $length) || (self::char_at($statement, $lookahead, $strlen) != '-')) {
+				if (($lookahead > $length) || (static::char_at($statement, $lookahead, $strlen) != '-')) {
 					$this->tuples[] = array(
-						'type' => self::OPERATOR_TOKEN,
+						'type' => static::OPERATOR_TOKEN,
 						'token' => $char,
 					);
 					$this->size++;
 					// echo Debug::vars($char);
 				}
 				else {
-					while ( ! in_array(self::char_at($statement, $lookahead, $strlen), $eol)) {
+					while ( ! in_array(static::char_at($statement, $lookahead, $strlen), $eol)) {
 						$lookahead++;
 					}
 					$lookahead++;
 					$size = min($lookahead, $strlen) - $position;
 					$token = substr($statement, $position, $size);
 					$this->tuples[] = array(
-						'type' => self::WHITESPACE_TOKEN,
+						'type' => static::WHITESPACE_TOKEN,
 						'token' => $token,
 					);
 					$this->size++;
@@ -299,10 +299,10 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 			}
 			else if ($char == '/') { // "whitespace" token (i.e. C-style comment) or "operator" token
 				$lookahead = $position + 1;
-				$next = self::char_at($statement, $lookahead, $strlen);
+				$next = static::char_at($statement, $lookahead, $strlen);
 				if ($next != '*') {
 					$this->tuples[] = array(
-						'type' => self::OPERATOR_TOKEN,
+						'type' => static::OPERATOR_TOKEN,
 						'token' => $char,
 					);
 					$this->size++;
@@ -310,14 +310,14 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 				}
 				else {
 					$lookahead += 2;
-					while ( ! ((self::char_at($statement, $lookahead - 1, $strlen) == '*') && (self::char_at($statement, $lookahead, $strlen) == '/'))) {
+					while ( ! ((static::char_at($statement, $lookahead - 1, $strlen) == '*') && (static::char_at($statement, $lookahead, $strlen) == '/'))) {
 						$lookahead++;
 					}
 					$lookahead++;
 					$size = min($lookahead, $length + 1) - $position;
 					$token = substr($statement, $position, $size);
 					$this->tuples[] = array(
-						'type' => self::WHITESPACE_TOKEN,
+						'type' => static::WHITESPACE_TOKEN,
 						'token' => $token,
 					);
 					$this->size++;
@@ -329,12 +329,12 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 				$start = $position;
 				do {
 					$position++;
-				} while(($position < $length) && (self::char_at($statement, $position, $strlen) != ']'));
+				} while(($position < $length) && (static::char_at($statement, $position, $strlen) != ']'));
 				$position++;
 				$size = $position - $start;
 				$token = substr($statement, $start, $size);
 				$this->tuples[] = array(
-					'type' => self::IDENTIFIER_TOKEN,
+					'type' => static::IDENTIFIER_TOKEN,
 					'token' => $token,
 				);
 				$this->size++;
@@ -344,12 +344,12 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 				$start = $position;
 				do {
 					$position++;
-				} while(($position < $length) && (self::char_at($statement, $position, $strlen) != $char));
+				} while(($position < $length) && (static::char_at($statement, $position, $strlen) != $char));
 				$position++;
 				$size = $position - $start;
 				$token = substr($statement, $start, $size);
 				$this->tuples[] = array(
-					'type' => self::IDENTIFIER_TOKEN,
+					'type' => static::IDENTIFIER_TOKEN,
 					'token' => $token,
 				);
 				$this->size++;
@@ -358,8 +358,8 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 			else if ($char == '\'') { // "literal" token
 				$lookahead = $position + 1;
 				while ($lookahead <= $length) {
-					if (self::char_at($statement, $lookahead, $strlen) == '\'') {
-						if (($lookahead == $length) || (self::char_at($statement, $lookahead + 1, $strlen) != '\'')) {
+					if (static::char_at($statement, $lookahead, $strlen) == '\'') {
+						if (($lookahead == $length) || (static::char_at($statement, $lookahead + 1, $strlen) != '\'')) {
 							$lookahead++;
 							break;
 						}
@@ -370,7 +370,7 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 				$size = $lookahead - $position;
 				$token = substr($statement, $position, $size);
 				$this->tuples[] = array(
-					'type' => self::LITERAL_TOKEN,
+					'type' => static::LITERAL_TOKEN,
 					'token' => $token,
 				);
 				$this->size++;
@@ -383,39 +383,39 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 				$next = '';
 				if ($char == '0') {
 					$position++;
-					$next = self::char_at($statement, $position, $strlen);
+					$next = static::char_at($statement, $position, $strlen);
 					if (($next == 'x') || ($next == 'X')) {
 						do {
 							$position++;
-							$next = self::char_at($statement, $position, $strlen);
+							$next = static::char_at($statement, $position, $strlen);
 						} while (($next >= '0') && ($next <= '9'));
-						$type = self::HEXADECIMAL_TOKEN;
+						$type = static::HEXADECIMAL_TOKEN;
 					}
 					else if ($next == '.') {
 						do {
 							$position++;
-							$next = self::char_at($statement, $position, $strlen);
+							$next = static::char_at($statement, $position, $strlen);
 						} while (($next >= '0') && ($next <= '9'));
-						$type = self::REAL_TOKEN;
+						$type = static::REAL_TOKEN;
 					}
 					else {
-						$type = self::INTEGER_TOKEN;
+						$type = static::INTEGER_TOKEN;
 					}
 				}
 				else {
 					do {
 						$position++;
-						$next = self::char_at($statement, $position, $strlen);
+						$next = static::char_at($statement, $position, $strlen);
 					} while (($next >= '0') && ($next <= '9'));
 					if ($next == '.') {
 						do {
 							$position++;
-							$next = self::char_at($statement, $position, $strlen);
+							$next = static::char_at($statement, $position, $strlen);
 						} while (($next >= '0') && ($next <= '9'));
-						$type = self::REAL_TOKEN;
+						$type = static::REAL_TOKEN;
 					}
 					else {
-						$type = self::INTEGER_TOKEN;
+						$type = static::INTEGER_TOKEN;
 					}
 				}
 				$size = $position - $start;
@@ -432,11 +432,11 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 				$next = '';
 				do {
 					$position++;
-					$next = self::char_at($statement, $position, $strlen);
+					$next = static::char_at($statement, $position, $strlen);
 				} while(($position <= $length) && ((($next >= 'a') && ($next <= 'z')) || (($next >= 'A') && ($next <= 'Z')) || ($next == '_') || (($next >= '0') && ($next <= '9'))));
 				$size = $position - $start;
 				$token = substr($statement, $start, $size);
-				$type = (self::is_keyword($token, $dialect)) ? self::KEYWORD_TOKEN : self::IDENTIFIER_TOKEN;
+				$type = (static::is_keyword($token, $dialect)) ? static::KEYWORD_TOKEN : static::IDENTIFIER_TOKEN;
 				$this->tuples[] = array(
 					'type' => $type,
 					'token' => $token,
@@ -453,13 +453,13 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 					case '%':
 					case '&':
 					case '~':
-						$type = self::OPERATOR_TOKEN;
+						$type = static::OPERATOR_TOKEN;
 					break;
 					case '?':
-						$type = self::PARAMETER_TOKEN;
+						$type = static::PARAMETER_TOKEN;
 					break;
 					case ';':
-						$type = self::TERMINAL_TOKEN;
+						$type = static::TERMINAL_TOKEN;
 					break;
 					default:
 						$type = $token;

--- a/classes/base/db/sql/tokenizer.php
+++ b/classes/base/db/sql/tokenizer.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category SQL
- * @version 2012-05-10
+ * @version 2012-08-18
  *
  * @see http://www.sqlite.org/c3ref/complete.html
  * @see http://www.opensource.apple.com/source/SQLite/SQLite-74/public_source/src/complete.c
@@ -664,7 +664,7 @@ abstract class Base_DB_SQL_Tokenizer extends Kohana_Object implements ArrayAcces
 	 */
 	public static function is_keyword($token, $dialect) {
 		$compiler = 'DB_' . $dialect . '_Expression';
-		$result = call_user_func(array($compiler, 'is_keyword'), $token);
+		$result = $compiler::is_keyword($token);
 		return $result;
 	}
 

--- a/classes/base/db/sql/update/builder.php
+++ b/classes/base/db/sql/update/builder.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category SQL
- * @version 2012-05-11
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -137,10 +137,10 @@ abstract class Base_DB_SQL_Update_Builder extends DB_SQL_Builder {
 			$this->data['where'][] = array($connector, "{$column} {$operator} {$value0} AND {$value1}");
 		}
 		else {
-			if ((($operator == DB_SQL_Operator::_IN_) || ($operator == DB_SQL_Operator::_NOT_IN_)) && ! is_array($value)) {
+			if (($operator == DB_SQL_Operator::_IN_ || $operator == DB_SQL_Operator::_NOT_IN_) && ! is_array($value)) {
 				throw new Kohana_SQL_Exception('Message: Invalid build instruction. Reason: Operator requires the value to be declared as an array.', array(':column' => $column, ':operator' => $operator, ':value' => $value, ':connector' => $connector));
 			}
-			if (is_null($value)) {
+			if ($value === NULL) {
 				switch ($operator) {
 					case DB_SQL_Operator::_EQUAL_TO_:
 						$operator = DB_SQL_Operator::_IS_;

--- a/classes/base/db/sqlite/connection/pdo.php
+++ b/classes/base/db/sqlite/connection/pdo.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category SQLite
- * @version 2012-05-22
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/ref.pdo-sqlite.php
  *
@@ -50,7 +50,7 @@ abstract class Base_DB_SQLite_Connection_PDO extends DB_SQL_Connection_PDO {
 					$attributes[PDO::ATTR_PERSISTENT] = TRUE;
 				}
 				$this->connection = new PDO($connection_string, '', '', $attributes);
-				$this->resource_id = self::$counter++;
+				$this->resource_id = static::$counter++;
 			}
 			catch (PDOException $ex) {
 				$this->connection = NULL;

--- a/classes/base/db/sqlite/connection/standard.php
+++ b/classes/base/db/sqlite/connection/standard.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category SQLite
- * @version 2012-05-25
+ * @version 2012-08-16
  *
  * @see http://www.php.net/manual/en/ref.sqlite.php
  *
@@ -81,7 +81,7 @@ abstract class Base_DB_SQLite_Connection_Standard extends DB_SQL_Connection_Stan
 			throw new Kohana_SQL_Exception('Message: Failed to query SQL statement. Reason: Unable to find connection.');
 		}
 		$result_set = $this->cache($sql, $type);
-		if ( ! is_null($result_set)) {
+		if ($result_set !== NULL) {
 			$this->sql = $sql;
 			return $result_set;
 		}

--- a/classes/base/db/sqlite/expression.php
+++ b/classes/base/db/sqlite/expression.php
@@ -408,7 +408,7 @@ abstract class Base_DB_SQLite_Expression implements DB_SQL_Expression_Interface 
 	 * @see http://www.sqlite.org/lang_keywords.html
 	 */
 	public static function is_keyword($token) {
-		if (is_null(static::$xml)) {
+		if (static::$xml === NULL) {
 			static::$xml = XML::load('config/sql/sqlite.xml');
 		}
 		$token = strtoupper($token);

--- a/classes/base/db/sqlite/expression.php
+++ b/classes/base/db/sqlite/expression.php
@@ -76,7 +76,7 @@ abstract class Base_DB_SQLite_Expression implements DB_SQL_Expression_Interface 
 		if ( ! is_string($expr)) {
 			throw new Kohana_InvalidArgument_Exception('Message: Invalid alias token specified. Reason: Token must be a string.', array(':expr' => $expr));
 		}
-		return self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . self::_CLOSING_QUOTE_CHARACTER_;
+		return static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $expr)) . static::_CLOSING_QUOTE_CHARACTER_;
 	}
 
 	/**
@@ -139,7 +139,7 @@ abstract class Base_DB_SQLite_Expression implements DB_SQL_Expression_Interface 
 		}
 		$parts = explode('.', $expr);
 		foreach ($parts as &$part) {
-			$part = self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . self::_CLOSING_QUOTE_CHARACTER_;
+			$part = static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $part)) . static::_CLOSING_QUOTE_CHARACTER_;
 		}
 		$expr = implode('.', $parts);
 		return $expr;
@@ -341,7 +341,7 @@ abstract class Base_DB_SQLite_Expression implements DB_SQL_Expression_Interface 
 				return "x'" . $expr->as_hexcode() . "'";
 			}
 			else {
-				return self::prepare_value( (string) $expr); // Convert the object to a string
+				return static::prepare_value( (string) $expr); // Convert the object to a string
 			}
 		}
 		else if (is_integer($expr)) {
@@ -376,7 +376,7 @@ abstract class Base_DB_SQLite_Expression implements DB_SQL_Expression_Interface 
 		$count = count($parts);
 		for ($i = 0; $i < $count; $i++) {
 			$parts[$i] = (trim($parts[$i]) != '*')
-				? self::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . self::_CLOSING_QUOTE_CHARACTER_
+				? static::_OPENING_QUOTE_CHARACTER_ . trim(preg_replace('/[^a-z0-9$_ ]/i', '', $parts[$i])) . static::_CLOSING_QUOTE_CHARACTER_
 				: '*';
 		}
 		if (isset($parts[$count - 1]) && ($parts[$count - 1] != '*')) {
@@ -408,11 +408,11 @@ abstract class Base_DB_SQLite_Expression implements DB_SQL_Expression_Interface 
 	 * @see http://www.sqlite.org/lang_keywords.html
 	 */
 	public static function is_keyword($token) {
-		if (is_null(self::$xml)) {
-			self::$xml = XML::load('config/sql/sqlite.xml');
+		if (is_null(static::$xml)) {
+			static::$xml = XML::load('config/sql/sqlite.xml');
 		}
 		$token = strtoupper($token);
-		$nodes = self::$xml->xpath("/sql/dialect[@name='sqlite' and @version='3.0']/keywords[keyword = '{$token}']");
+		$nodes = static::$xml->xpath("/sql/dialect[@name='sqlite' and @version='3.0']/keywords[keyword = '{$token}']");
 		return ! empty($nodes);
 	}
 

--- a/classes/base/db/sqlite/expression.php
+++ b/classes/base/db/sqlite/expression.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category SQLite
- * @version 2012-08-15
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -323,7 +323,7 @@ abstract class Base_DB_SQLite_Expression implements DB_SQL_Expression_Interface 
 		else if (is_array($expr)) {
 			$buffer = array();
 			foreach ($expr as $value) {
-				$buffer[] = call_user_func_array(array($this, __FUNCTION__), array($value, $escape));
+				$buffer[] = $this->prepare_value($value, $escape);
 			}
 			return DB_SQL_Builder::_OPENING_PARENTHESIS_ . implode(', ', $buffer) . DB_SQL_Builder::_CLOSING_PARENTHESIS_;
 		}

--- a/classes/base/db/sqlite/select/builder.php
+++ b/classes/base/db/sqlite/select/builder.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category SQL
- * @version 2012-02-22
+ * @version 2012-08-16
  *
  * @see http://www.sqlite.org/lang_select.html
  *
@@ -48,7 +48,7 @@ abstract class Base_DB_SQLite_Select_Builder extends DB_SQL_Select_Builder {
 			? implode(', ', $this->data['column'])
 			: $this->data['wildcard'];
 
-		if ( ! is_null($this->data['from'])) {
+		if ($this->data['from'] !== NULL) {
 			$sql .= " FROM {$this->data['from']}";
 		}
 

--- a/classes/base/xml.php
+++ b/classes/base/xml.php
@@ -22,7 +22,7 @@
  *
  * @package Leap
  * @category XML
- * @version 2012-05-31
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -40,7 +40,7 @@ abstract class Base_XML extends SimpleXMLElement {
 	 *                                              formatted string
 	 */
 	public static function encode(Array $array, $as_string = FALSE) {
-		$content = self::convert_to_xml($array);
+		$content = static::convert_to_xml($array);
 		if ($as_string) {
 			return $content;
 		}
@@ -65,7 +65,7 @@ abstract class Base_XML extends SimpleXMLElement {
 			throw new Kohana_InvalidArgument_Exception('Message: Wrong data type specified. Reason: Argument must be a string.', array(':type', gettype($file)));
 		}
 
-		$source = self::find_file($file);
+		$source = static::find_file($file);
 
 		$content = file_get_contents($source);
 
@@ -91,7 +91,7 @@ abstract class Base_XML extends SimpleXMLElement {
 		if (is_null($DOMDocument)) {
 			$DOMDocument = new DOMDocument();
 			$DOMDocument->formatOutput = TRUE;
-			self::convert_to_xml($array, $DOMDocument, $DOMDocument);
+			static::convert_to_xml($array, $DOMDocument, $DOMDocument);
 			return $DOMDocument->asXML();
 		} else {
 			if (is_array($array)) {
@@ -103,7 +103,7 @@ abstract class Base_XML extends SimpleXMLElement {
 						$element = $DOMDocument->createElement($node);
 						$domElement->appendChild($element);
 					}
-					self::convert_to_xml($value, $element, $DOMDocument);
+					static::convert_to_xml($value, $element, $DOMDocument);
 				}
 			} else {
 				if (is_string($array) && preg_match('/^<!CDATA\[.*\]\]>$/', $array)) {

--- a/classes/base/xml.php
+++ b/classes/base/xml.php
@@ -88,7 +88,7 @@ abstract class Base_XML extends SimpleXMLElement {
 	 * @see http://darklaunch.com/2009/05/23/php-xml-encode-using-domdocument-convert-array-to-xml-json-encode
 	 */
 	protected static function convert_to_xml($array, $domElement = NULL, $DOMDocument = NULL) {
-		if (is_null($DOMDocument)) {
+		if ($DOMDocument === NULL) {
 			$DOMDocument = new DOMDocument();
 			$DOMDocument->formatOutput = TRUE;
 			static::convert_to_xml($array, $DOMDocument, $DOMDocument);

--- a/classes/kohana/object.php
+++ b/classes/kohana/object.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category Object
- * @version 2012-08-14
+ * @version 2012-08-16
  *
  * @abstract
  */
@@ -35,80 +35,6 @@ abstract class Kohana_Object {
 	 */
 	public function __hashCode() {
 		return spl_object_hash($this);
-	}
-
-	/**
-	 * This function allows for an inheriting class to determine its child classes.
-	 *
-	 * Retro-support of get_called_class()
-	 * Tested and works in PHP 5.2.4
-	 *
-	 * @access public
-	 * @final
-	 * @static
-	 * @param array $backtrace          the generated backtrace
-	 * @param integer $level            the depth level
-	 * @return string                   the name of the called class
-	 *
-	 * @see http://php.net/manual/en/function.get-called-class.php
-	 * @see http://www.sol1.com.au/
-	 */
-	public final static function get_called_class($backtrace = FALSE, $level = 1) {
-		if ( ! $backtrace) {
-			$backtrace = debug_backtrace();
-		}
-		if ( ! isset($backtrace[$level])) {
-			throw new Kohana_ClassNotFound_Exception('Message: Cannot find called class. Reason: Stack level too deep.', array(':backtrace' => $backtrace, ':level' => $level));
-		}
-		if ( ! isset($backtrace[$level]['type'])) {
-			throw new Kohana_ClassNotFound_Exception('Message: Cannot find called class. Reason: Type not set.', array(':backtrace' => $backtrace, ':level' => $level));
-		}
-		else {
-			switch ($backtrace[$level]['type']) {
-				case '::':
-					try {
-						$lines = file($backtrace[$level]['file']);
-						$i = 0;
-						$callerLine = '';
-						do {
-							$i++;
-							$callerLine = $lines[$backtrace[$level]['line'] - $i] . $callerLine;
-						} while (stripos($callerLine, $backtrace[$level]['function']) === FALSE);
-						preg_match('/([a-zA-Z0-9\_]+)::' . $backtrace[$level]['function'] . '/', $callerLine, $matches);
-						if ( ! isset($matches[1])) {
-							// must be an edge case.
-							throw new Kohana_ClassNotFound_Exception('Message: Cannot find called class. Reason: Originating method call is obscured.', array(':backtrace' => $backtrace, ':level' => $level));
-						}
-						switch ($matches[1]) {
-							case 'self':
-							case 'parent':
-								return self::get_called_class($backtrace, $level + 1);
-							default:
-								return $matches[1];
-						}
-					}
-					catch (ErrorException $ex) {
-						throw new Kohana_ClassNotFound_Exception('Message: Cannot find called class. Reason: :exception', array(':exception' => $ex->getMessage(), ':backtrace' => $backtrace, ':level' => $level));
-					}
-				break;
-				case '->':
-					switch ($backtrace[$level]['function']) {
-						case '__get':
-							// edge case -> get class of calling object
-							if (!is_object($backtrace[$level]['object'])) {
-								throw new Kohana_ClassNotFound_Exception('Message: Cannot find called class. Reason: Edge case fail. __get called on non object.', array(':backtrace' => $backtrace, ':level' => $level));
-							}
-							return get_class($backtrace[$level]['object']);
-						break;
-						default:
-							return $backtrace[$level]['class'];
-						break;
-					}
-				default:
-					throw new Kohana_ClassNotFound_Exception('Message: Cannot find called class. Reason: Unknown backtrace method type.', array(':backtrace' => $backtrace, ':level' => $level));
-				break;
-			}
-		}
 	}
 
 }


### PR DESCRIPTION
As we talked with @bluesnowman yesterday, Leap is leaving PHP 5.2.x in branch 3.2/legacy and move on to PHP 5.3.x, so we can use really needed functionality.
1.  I got rid of most call_user_func() and use static:: instead. There are things that couldn't be done without it.
2.  I changed all `self::` to `static::`, because it's the right way to make everything extendable. In few 3.  places that `self::` strategy actually was giving unexpected results.
3.  I got rid of `is_null($value)` and now using `$value === NULL` instead, because it's just better performance (at least twice as fast or more).
4.  I did replace `is_field()`, `is_alias()` and `is_adaptor()` with `isset()` in places where it didn't make sense, so I did gain a little performance.
5.  In function `as_array()` there was no adaptors or aliases values included, so I added them.
6.  I modified `save()` function and added `create()` and `update()` functions, so the issue #62 is now solved. I found it more useful to leave the main functionality in `save()` function and not to duplicate code in newly created ones.
7.  In my previous pull request I did introduce ability to set the 'default' field value setting to NULL, because you may want the default value to be a NULL, but it wasn't actually added to the repository, so I did it again. The thing is that `isset()` returns FALSE, if the value is NULL, so now we are using `array_key_exists()`.

One day spent. That's all for now. I hope you will like it. ;)

Next to come: model validation. I will probably talk more about this with @bluesnowman before pushing.
