### PR TITLE
Fix static binding

### DIFF
--- a/classes/base/db/orm.php
+++ b/classes/base/db/orm.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-20
+ * @version 2012-08-21
  *
  * @abstract
  */
@@ -85,7 +85,7 @@ abstract class Base_DB_ORM extends Kohana_Object {
 			if ( ! is_array($primary_key)) {
 				$primary_key = array($primary_key);
 			}
-			$model_key = call_user_func(array(get_class($model), 'primary_key'));
+			$model_key = $model::primary_key();
 			$count = count($model_key);
 			for ($i = 0; $i < $count; $i++) {
 				$column = $model_key[$i];

--- a/classes/base/db/orm/relation/belongsto.php
+++ b/classes/base/db/orm/relation/belongsto.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-16
+ * @version 2012-08-21
  *
  * @abstract
  */
@@ -40,10 +40,14 @@ abstract class Base_DB_ORM_Relation_BelongsTo extends DB_ORM_Relation {
 		// the parent model is the referenced table
 		$this->metadata['parent_model'] = DB_ORM_Model::model_name($metadata['parent_model']);
 
+		// Get parent model's name into variable, otherways a late static binding code throws a
+		// syntax error when used like this: $this->metadata['parent_model']::primary_key()
+		$parent_model = $this->metadata['parent_model'];
+
 		// the parent key (i.e. candidate key) is an ordered list of field names in the parent model
 		$this->metadata['parent_key'] = (isset($metadata['parent_key']))
 			? (array) $metadata['parent_key']
-			: $this->metadata['parent_model']::primary_key();
+			: $parent_model::primary_key();
 
 		// the child model is the referencing table
 		$this->metadata['child_model'] = get_class($model);

--- a/classes/base/db/orm/relation/hasmany.php
+++ b/classes/base/db/orm/relation/hasmany.php
@@ -40,10 +40,14 @@ abstract class Base_DB_ORM_Relation_HasMany extends DB_ORM_Relation {
 		// the parent model is the referenced table
 		$this->metadata['parent_model'] = get_class($model);
 
+		// Get parent model's name into variable, otherways a late static binding code throws a
+		// syntax error when used like this: $this->metadata['parent_model']::primary_key()
+		$parent_model = $this->metadata['parent_model'];
+
 		// the parent key (i.e. candidate key) is an ordered list of field names in the parent model
 		$this->metadata['parent_key'] = (isset($metadata['parent_key']))
 			? (array) $metadata['parent_key']
-			: $this->metadata['parent_model']::primary_key();
+			: $parent_model::primary_key();
 
 		// the through model is the pivot table
 		if (isset($metadata['through_model'])) {

--- a/classes/base/db/orm/relation/hasone.php
+++ b/classes/base/db/orm/relation/hasone.php
@@ -21,7 +21,7 @@
  *
  * @package Leap
  * @category ORM
- * @version 2012-08-16
+ * @version 2012-08-21
  *
  * @abstract
  */
@@ -40,10 +40,14 @@ abstract class Base_DB_ORM_Relation_HasOne extends DB_ORM_Relation {
 		// the parent model is the referenced table
 		$this->metadata['parent_model'] = get_class($model);
 
+		// Get parent model's name into variable, otherways a late static binding code throws a
+		// syntax error when used like this: $this->metadata['parent_model']::primary_key()
+		$parent_model = $this->metadata['parent_model'];
+
 		// the parent key (i.e. candidate key) is an ordered list of field names in the parent model
 		$this->metadata['parent_key'] = (isset($metadata['parent_key']))
 			? (array) $metadata['parent_key']
-			: $this->metadata['parent_model']::primary_key();
+			: $parent_model::primary_key();
 
 		// the child model is the referencing table
 		$this->metadata['child_model'] = DB_ORM_Model::model_name($metadata['child_model']);


### PR DESCRIPTION
I don't know about other versions, but at least on PHP 5.4.5 the static binding syntax doestn't allow this:

``` php
<?php
$this->metadata['parent_model']::primary_key();
// Parse error: syntax error, unexpected '::' (T_PAAMAYIM_NEKUDOTAYIM)
```
