### PR TITLE
3.2/master BUG FIXES

### DIFF
--- a/classes/base/auth/leap.php
+++ b/classes/base/auth/leap.php
@@ -88,7 +88,7 @@ abstract class Base_Auth_Leap extends Auth {
 
 		if (isset($config['columns'])) {
 			if (isset($config['columns']['role_id'])) {
-				$this->columns['role_name'] = $config['columns']['role_id'];
+				$this->columns['role_id'] = $config['columns']['role_id'];
 			}
 			if (isset($config['columns']['role_name'])) {
 				$this->columns['role_name'] = $config['columns']['role_name'];

--- a/classes/base/db/mysql/expression.php
+++ b/classes/base/db/mysql/expression.php
@@ -347,7 +347,7 @@ abstract class Base_DB_MySQL_Expression implements DB_SQL_Expression_Interface {
 		else if (is_string($expr) AND preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}(\s[0-9]{2}:[0-9]{2}:[0-9]{2})?$/', $expr)) {
 			return "'{$expr}'";
 		}
-		else if (empty($expr)) {
+		else if ($expr === '') {
 			return "''";
 		}
 		else {

--- a/classes/base/db/orm/insert/proxy.php
+++ b/classes/base/db/orm/insert/proxy.php
@@ -146,7 +146,7 @@ abstract class Base_DB_ORM_Insert_Proxy extends Kohana_Object implements DB_SQL_
 	 * @return integer                              the last insert id
 	 */
 	public function execute() {
-		$auto_increment = $this->model::is_auto_incremented();
+        $auto_increment = call_user_func($this->model, 'is_auto_incremented');
 		$connection = DB_Connection_Pool::instance()->get_connection($this->source);
 		$connection->execute($this->statement());
 		$primary_key = ($auto_increment) ? $connection->get_last_insert_id() : 0;

--- a/classes/base/session/leap.php
+++ b/classes/base/session/leap.php
@@ -173,10 +173,8 @@ abstract class Base_Session_Leap extends Session {
 			$id = str_replace('.', '-', uniqid(NULL, TRUE));
             $count = DB_ORM::select($this->_table, array($this->_columns['session_id']))
                 ->where($this->_columns['session_id'], '=', $id)
-                ->limit(1)
                 ->query()
-                ->fetch(0)
-                ->id;
+                ->count();
 		}
 		while ($count > 0);
 

--- a/classes/base/session/leap.php
+++ b/classes/base/session/leap.php
@@ -133,6 +133,7 @@ abstract class Base_Session_Leap extends Session {
 	 */
 	protected function _read($id = NULL) {
 		if ($id OR $id = Cookie::get($this->_name)) {
+            
 			try {
 				$contents = DB_ORM::select($this->_table, array($this->_columns['contents']))
 					->where($this->_columns['session_id'], DB_SQL_Operator::_EQUAL_TO_, $id)
@@ -170,20 +171,14 @@ abstract class Base_Session_Leap extends Session {
 		do {
 			// Create a new session id
 			$id = str_replace('.', '-', uniqid(NULL, TRUE));
-
-			try {
-				$result = DB_ORM::select($this->_table, array($this->_columns['session_id']))
-					->where($this->_columns['session_id'], DB_SQL_Operator::_EQUAL_TO_, $id)
-					->limit(1)
-					->query()
-					->fetch(0)
-					->id;
-			}
-			catch (ErrorException $ex) {
-				$result = FALSE;
-			}
+            $count = DB_ORM::select($this->_table, array($this->_columns['session_id']))
+                ->where($this->_columns['session_id'], '=', $id)
+                ->limit(1)
+                ->query()
+                ->fetch(0)
+                ->id;
 		}
-		while ($result !== FALSE);
+		while ($count > 0);
 
 		return $this->_session_id = $id;
 	}


### PR DESCRIPTION
HOTFIX: Session _regenerate() was not working when notices were turned off because the function was using the exception and a breaking condition

AND

HOTFIX **_MYSQL ONLY**_: Fixed bug where you could not save a string of value "0" as it was triggering FALSE for empty();

See here: http://php.net/manual/en/types.comparisons.php

PLEASE NOTE THAT THIS HAS ONLY BEEN ADJUSTED IN THE MYSQL/EXPRESSION.PHP file!
