### PR TITLE
Update classes/Base/DB/MySQL/Select/Builder.php

### DIFF
--- a/classes/Base/DB/MySQL/Select/Builder.php
+++ b/classes/Base/DB/MySQL/Select/Builder.php
@@ -60,7 +60,7 @@ abstract class Base_DB_MySQL_Select_Builder extends DB_SQL_Select_Builder {
 				$sql .= ' ON (' . implode(' AND ', $join[1]) . ')';
 			}
 			else if ( ! empty($join[2])) {
-				$sql .= ' USING ' . implode(', ', $join[2]);
+				$sql .= ' USING (' . implode(', ', $join[2]).')';
 			}
 		}
 


### PR DESCRIPTION
There was an error in Builder.php where using "using" in a query output incorrect syntax

IE 

SELECT \* FROM foo INNER JOIN bar USING `foo_id`

The statement method was missing parenthesis, fixed it now outputs: 

SELECT \* FROM foo INNER JOIN bar USING (`foo_id`)
