### PR TITLE
Fixed

### DIFF
--- a/classes/Base/DB/MsSQL/Update/Builder.php
+++ b/classes/Base/DB/MsSQL/Update/Builder.php
@@ -80,13 +80,15 @@ abstract class Base_DB_MsSQL_Update_Builder extends DB_SQL_Update_Builder {
 		$table = str_replace(DB_MsSQL_Precompiler::_OPENING_QUOTE_CHARACTER_, '', $table);
 		$table = str_replace(DB_MsSQL_Precompiler::_CLOSING_QUOTE_CHARACTER_, '', $table);
 
-		$identity_column = DB_SQL::select('default')
-							->from('INFORMATION_SCHEMA.COLUMNS')
-							->column('COLUMN_NAME')
-							->where('TABLE_SCHEMA', '=', 'dbo')
-							->where(DB_SQL::expr('COLUMNPROPERTY(object_id(TABLE_NAME), COLUMN_NAME, \'IsIdentity\')'), '=', 1)
-							->where('TABLE_NAME', '=', $table)
-							->query()->get('COLUMN_NAME');
+		$ts = DB_SQL::select('default')
+				->from('INFORMATION_SCHEMA.COLUMNS')
+				->column('COLUMN_NAME')
+				->where('TABLE_SCHEMA', '=', 'dbo')
+				->where(DB_SQL::expr('COLUMNPROPERTY(object_id(TABLE_NAME), COLUMN_NAME, \'IsIdentity\')'), '=', 1)
+				->where('TABLE_NAME', '=', $table)
+				->query();
+
+		$identity_column = $ts->is_loaded() ? $ts->get('COLUMN_NAME') : NULL;
 
 		if ( ! empty($this->data['column'])) {
 			$column = $this->data['column'];


### PR DESCRIPTION
Recently, I found a little bug in my previous edit, where check the Identity column if exists or not in a table.  I added an extra validation to check if the result is loaded or not, so I can get the name of the column (line 91).  Hope this helps.
